### PR TITLE
fix byte-compile warnings

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -39,6 +39,8 @@
 (require 'auto-complete-clang)
 (require 'flycheck)
 
+(declare-function rtags-call-rc "rtags")
+
 (defvar cmake-ide-flags-c
   nil
   "The C compiler flags to use.  Should have -I flags for system includes.")


### PR DESCRIPTION
I got following error when byte-compile.

```
In end of data:
cmake-ide.el:339:1:Warning: the function `rtags-call-rc' is not known to be
    defined.
```
