### PR TITLE
Declare dependency on Emacs 24

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -4,7 +4,7 @@
 
 ;; Author:  Atila Neves <atila.neves@gmail.com>
 ;; Version: 0.1
-;; Package-Requires: ((auto-complete-clang "0.1") (flycheck "0.17"))
+;; Package-Requires: ((emacs "24") (auto-complete-clang "0.1") (flycheck "0.17"))
 ;; Keywords: languages
 ;; URL: http://github.com/atilaneves/cmake-ide
 


### PR DESCRIPTION
You're using `lexical-binding`, for which Emacs 24 is required. (Flycheck requires Emacs 24, but it's best to declare dependencies directly when they're known.)

In connection with https://github.com/milkypostman/melpa/pull/1977
