### PR TITLE
Do local add-hook to find-file-hook.

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -81,7 +81,7 @@
 (defun cmake-ide-setup ()
   "Set up the Emacs hooks for working with CMake projects."
   (add-hook 'c-mode-common-hook (lambda ()
-                                  (add-hook 'find-file-hook #'cmake-ide--maybe-run-cmake)
+                                  (add-hook 'find-file-hook #'cmake-ide--maybe-run-cmake nil 'local)
                                   (when (and (featurep 'rtags) (cmake-ide--locate-cmakelists))
                                     (cmake-ide-maybe-start-rdm))))
 


### PR DESCRIPTION
This fixes so finding a non-c/c++ file, after having worked in a C++ file won't trigger `cmake-ide--maybe-run-cmake`.