### PR TITLE
Pass std argument to flycheck etc. when present.

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -285,15 +285,15 @@ flags."
     (mapconcat 'identity flags " ")))
 
 
-(defun cmake-ide--args-to-include-and-define-flags (args)
-  "Filters a list of compiler command ARGS to yield only includes and defines."
+(defun cmake-ide--args-to-include-define-and-std-flags (args)
+  "Filters a list of compiler command ARGS to yield only includes, defines and standards."
   (let ((case-fold-search)) ;; case sensitive matching
-    (cmake-ide--filter (lambda (x) (string-match "^-[IFD].+\\b" x)) args)))
+    (cmake-ide--filter (lambda (x) (string-match "^-\\([IFD]\\|std\\).+\\b" x)) args)))
 
 (defun cmake-ide--params-to-src-flags (file-params &optional filter-func)
   "Source compiler flags for FILE-PARAMS using FILTER-FUNC."
   (if (not file-params) nil
-    (let* ((filter-func (or filter-func #'cmake-ide--args-to-include-and-define-flags))
+    (let* ((filter-func (or filter-func #'cmake-ide--args-to-include-define-and-std-flags))
            (value (cmake-ide--filter-params file-params filter-func))
            (flags-string (if value value nil)))
       (if flags-string (split-string flags-string " +") nil))))
@@ -302,7 +302,7 @@ flags."
 (defun cmake-ide--commands-to-hdr-flags (commands)
   "Header compiler flags from COMMANDS."
   (let ((args (cmake-ide--flatten (mapcar (lambda (x) (split-string x " +")) commands))))
-    (delete-dups (cmake-ide--args-to-include-and-define-flags args))))
+    (delete-dups (cmake-ide--args-to-include-define-and-std-flags args))))
 
 (defun cmake-ide--params-to-src-includes (file-params)
   "-include compiler flags for from FILE-PARAMS."

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -47,17 +47,17 @@
 (ert-deftest test-params-to-src-flags-1 ()
   (let* ((json (cmake-ide--string-to-json
                 "[{\"file\": \"file1\",
-                  \"command\": \"cmd1 -Ifoo -Ibar\"},
+                  \"command\": \"cmd1 -Ifoo -Ibar -std=c++14\"},
                  {\"file\": \"file2\",
                   \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]"))
          (file-params (cmake-ide--file-params json "file1")))
     (should (equal (cmake-ide--params-to-src-flags file-params)
-                   '("-Ifoo" "-Ibar")))))
+                   '("-Ifoo" "-Ibar" "-std=c++14")))))
 
 (ert-deftest test-params-to-src-flags-2 ()
   (let* ((json (cmake-ide--string-to-json
                 "[{\"file\": \"file1\",
-                  \"command\": \"cmd1 -Ifoo -Ibar\"},
+                  \"command\": \"cmd1 -Ifoo -Ibar -std=c++14\"},
                  {\"file\": \"file2\",
                   \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]"))
          (file-params (cmake-ide--file-params json "file2")))


### PR DESCRIPTION
Flycheck-clang and company-clang don't work on e.g. C++14 codebases without this.