### PR TITLE
Fix: don't pass a nil string to string-match

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -610,9 +610,14 @@ flags."
 (defun cmake-ide--system-process-running-p (name)
   "If a process called NAME is running on the system."
   (let* ((all-args (mapcar (lambda (x) (cdr (assq 'args (process-attributes x)))) (list-system-processes)))
-         (match-args (cmake-ide--filter (lambda (x) (string-match (concat "\\b" name "\\b") x)) all-args))
+         (match-args (cmake-ide--filter (lambda (x) (cmake-ide--string-match (concat "\\b" name "\\b") x)) all-args))
          )
     (not (null match-args))))
+
+(defun cmake-ide--string-match (regexp name)
+  "Wrap string-match to make sure we don't pass it a nil string."
+  (when name
+    (string-match regexp name)))
 
 
 (provide 'cmake-ide)


### PR DESCRIPTION
In Ubuntu 15.10 process 0 return a nil "args" process-attribute.
cmake-ide--system-process-running-p would failed and report a
"wrong-type-argument stringp nil" error.

This error was fixed by wrapping the string-match into a
cmake-ide--string-match that guarantee no nil string is passed to
string-match.