### PR TITLE
Feature: create cmake-ide-dir directory when missing

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -352,6 +352,8 @@ flags."
 (defun cmake-ide--get-build-dir ()
   "Return the directory name to run CMake in."
   (when (not cmake-ide-dir) (setq cmake-ide-dir (make-temp-file "cmake" t)))
+  (if (not (file-accessible-directory-p cmake-ide-dir))
+      (make-directory cmake-ide-dir))
   (file-name-as-directory cmake-ide-dir))
 
 


### PR DESCRIPTION
If cmake-ide-dir was configured to a non existing directory
cmake-ide--get-build-dir would generate an stringp nil error.
Now if the cmake-ide-dir does not exist it will be created and then
used as the build directory.