### PR TITLE
handle correctly ccache when used as symlink

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -431,7 +431,8 @@ flags."
 (defun cmake-ide--remove-compiler-from-args (str)
   "Remove the compiler command from STR, leaving only arguments."
   (let ((args (split-string str " +")))
-    (if (string-match "ccache" (car args))
+    (if (and (string-match "ccache" (car args))
+             (not (string-match "lib/ccache" (car args))))
         (cddr args)
       (cdr args))))
 

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -203,6 +203,13 @@
     (should (equal flycheck-clang-language-standard "c++14"))
     (should (equal-lists flycheck-clang-args '("-S" "-F" "-g")))))
 
+(ert-deftest test-all-vars-ccache-alt ()
+  (let ((idb (cmake-ide--cdb-json-string-to-idb
+              "[{\"file\": \"file1.c\",
+                  \"command\": \"/usr/lib/ccache/bin/clang++ -Iinc1 -Iinc2 -Dfoo=bar -S -F -g -std=c++14\"}]")))
+    (cmake-ide--set-flags-for-file idb (current-buffer))
+    (should (equal-lists ac-clang-flags '("-Iinc1" "-Iinc2" "-Dfoo=bar" "-S" "-F" "-g" "-std=c++14")))))
+
 (ert-deftest test-idb-obj-get ()
   (let* ((idb (cmake-ide--cdb-json-string-to-idb
                "[{\"file\": \"file1.c\", \"foo\": \"the foo is mighty\", \"bar\": \"the bar is weak\"}]"))


### PR DESCRIPTION
When ccache is used as a symlink, the compiler is the first argument of
the flags, and has the form: /usr/lib/ccache/bin/<compiler>. This is
different from having 'ccache <compiler>'.