### PR TITLE
Support for cmake-ide-dir paths relative to project directory

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -441,6 +441,9 @@ the object file's name just above."
 (defun cmake-ide--get-build-dir ()
   "Return the directory name to run CMake in."
   (when (not cmake-ide-dir) (setq cmake-ide-dir (make-temp-file "cmake" t)))
+  (when (not (or (string-prefix-p "/" cmake-ide-dir)
+				 (string-prefix-p "~" cmake-ide-dir)))
+	(setq cmake-ide-dir (concat (cmake-ide--locate-cmakelists) cmake-ide-dir)))
   (if (not (file-accessible-directory-p cmake-ide-dir))
       (make-directory cmake-ide-dir))
   (file-name-as-directory cmake-ide-dir))

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -441,9 +441,8 @@ the object file's name just above."
 (defun cmake-ide--get-build-dir ()
   "Return the directory name to run CMake in."
   (when (not cmake-ide-dir) (setq cmake-ide-dir (make-temp-file "cmake" t)))
-  (when (not (or (string-prefix-p "/" cmake-ide-dir)
-				 (string-prefix-p "~" cmake-ide-dir)))
-	(setq cmake-ide-dir (concat (cmake-ide--locate-cmakelists) cmake-ide-dir)))
+  (when (not (file-name-absolute-p cmake-ide-dir))
+	(setq cmake-ide-dir (expand-file-name cmake-ide-dir (cmake-ide--locate-cmakelists))))
   (if (not (file-accessible-directory-p cmake-ide-dir))
       (make-directory cmake-ide-dir))
   (file-name-as-directory cmake-ide-dir))


### PR DESCRIPTION
I usually want my build dir alongside other directories of a project like src or doc.
Currently you would have to set cmake-ide-dir to some absolute, possibly long path for example via dir locals.

This patch enables one to set a path relative to the project directory instead.
The old behavior should not be affected with respect to absolute paths if I didnt miss anything.