### PR TITLE
Fix `start-process` parameters order in `cmake-ide--run-cmake-impl`.

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -522,7 +522,7 @@ the object file's name just above."
   (when project-dir
     (let ((default-directory cmake-dir))
       (cmake-ide--message "Running cmake for src path %s in build path %s" project-dir cmake-dir)
-      (start-process cmake-ide-cmake-command "*cmake*" "cmake" "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" project-dir))))
+      (start-process "cmake" "*cmake*" cmake-ide-cmake-command "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" project-dir))))
 
 
 (defun cmake-ide--get-build-dir ()


### PR DESCRIPTION
Dead @atilaneves .

I think this is wrong parameters order with `start-process`.

Thanks.