### PR TITLE
Add build pool and persistent naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ definition" and everything else rtags offers.  This only works if both
 `rdm` and `rc` and in the system path or if `cmake-ide-rdm-executable`
 and `cmake-ide-rc-executable` are customized correctly.
 
+Build Pool Directories and Persistent Naming of Automatic Build Directories
+-----------------------------------------------------------------------------------
+
+`cmake-ide` can automatically create build directories for you -- either in the system's
+tmp-directory or under `cmake-ide-build-pool-dir` (if set). By default, all automatically
+created build directories (no matter where created) will have temporary and unique names,
+that will change with each new session and are thus not reusable. You can, however, by
+setting `cmake-ide-build-pool-use-persistent-naming` use a reproducible naming scheme that
+is based on the project's path and will not change as long as the project's path is the
+same. This way, you can reuse the build directory.
+
+By using both `cmake-ide-build-pool-dir` and `cmake-ide-build-pool-use-persistent-naming`,
+you can fully do away with the need to configure a build directory per project with directory
+local variables (for example).
+
 Non-CMake projects
 ------------------
 


### PR DESCRIPTION
Currently cmake-ide requires a configured build directory per project, if the build directory is to be reused.

This introduces the concept of a build pool directory, where all build directories are created. If it is not configured, the system's tmp is used (like previously done). This has the advantage that if tmp is size
limited (e.g. tmpfs), the user can specify a different global directory altogether for cmake-ide to use.

This also introduces the concept of persistent naming where the project's path is used as a basis for the build directory's name which is predictable and reproducible, making it possible to reuse the build
directory across different editing sessions.

If both are used, the user can do away with the need to configure a build directory per project.