### PR TITLE
FIxing issue with Relative file names in compilation database

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -303,15 +303,18 @@ flags."
 
 (defun cmake-ide--set-flags-for-file (idb buffer)
   "Set the compiler flags from IDB for BUFFER visiting file FILE-NAME."
+  "Proposed Fix for handling relative dirs: By checking if file-params is nil and trying with relative"
       (let* ((file-name (buffer-file-name buffer))
          (file-params (cmake-ide--idb-file-to-obj idb file-name))
-         (sys-includes (cmake-ide--params-to-sys-includes file-params))
+	     (rel-file-name (if file-name (file-relative-name file-name (cmake-ide--get-build-dir) nil)))
+	     (cor-file-params (if file-params file-params (cmake-ide--idb-file-to-obj idb rel-file-name)))
+         (sys-includes (cmake-ide--params-to-sys-includes cor-file-params))
          (commands (cmake-ide--idb-param-all-files idb 'command))
          (hdr-flags (cmake-ide--commands-to-hdr-flags commands)))
         (cmake-ide--message "Setting flags for file %s" file-name)
     ;; set flags for all source files that registered
     (if (cmake-ide--is-src-file file-name)
-        (cmake-ide--set-flags-for-src-file file-params buffer sys-includes)
+        (cmake-ide--set-flags-for-src-file cor-file-params buffer sys-includes)
       (cmake-ide--set-flags-for-hdr-file idb buffer (cmake-ide--flags-to-sys-includes hdr-flags)))))
 
 (defun cmake-ide--set-flags-for-src-file (file-params buffer sys-includes)

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -800,7 +800,7 @@ the object file's name just above."
   (let ((idb (make-hash-table :test #'equal))
         (json (json-read-from-string json-str)))
     (mapc (lambda (obj)
-            (let* ((file (cmake-ide--idb-obj-get obj 'file))
+            (let* ((file (cmake-ide--relativize (cmake-ide--idb-obj-get obj 'file)))
                    (objs (gethash file idb)))
               (push obj objs)
               (puthash file objs idb)))

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -303,18 +303,15 @@ flags."
 
 (defun cmake-ide--set-flags-for-file (idb buffer)
   "Set the compiler flags from IDB for BUFFER visiting file FILE-NAME."
-  "Proposed Fix for handling relative dirs: By checking if file-params is nil and trying with relative"
       (let* ((file-name (buffer-file-name buffer))
          (file-params (cmake-ide--idb-file-to-obj idb file-name))
-	     (rel-file-name (if file-name (file-relative-name file-name (cmake-ide--get-build-dir) nil)))
-	     (cor-file-params (if file-params file-params (cmake-ide--idb-file-to-obj idb rel-file-name)))
-         (sys-includes (cmake-ide--params-to-sys-includes cor-file-params))
+         (sys-includes (cmake-ide--params-to-sys-includes file-params))
          (commands (cmake-ide--idb-param-all-files idb 'command))
          (hdr-flags (cmake-ide--commands-to-hdr-flags commands)))
         (cmake-ide--message "Setting flags for file %s" file-name)
     ;; set flags for all source files that registered
     (if (cmake-ide--is-src-file file-name)
-        (cmake-ide--set-flags-for-src-file cor-file-params buffer sys-includes)
+        (cmake-ide--set-flags-for-src-file file-params buffer sys-includes)
       (cmake-ide--set-flags-for-hdr-file idb buffer (cmake-ide--flags-to-sys-includes hdr-flags)))))
 
 (defun cmake-ide--set-flags-for-src-file (file-params buffer sys-includes)

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -329,5 +329,22 @@
     (should (equal (cmake-ide--idb-obj-get real-params 'directory) "/foo/bar/dir"))
     (should (equal (cmake-ide--idb-obj-get fake-params 'directory) nil))))
 
+(ert-deftest test-issue-79 ()
+  (let ((cmake-ide-build-dir "/usr/bin")
+        (idb (cmake-ide--cdb-json-string-to-idb
+              "[
+ {
+ \"directory\": \"/usr/bin\",
+ \"command\": \" g++-6    -I../include   -g -std=c++14 -Wall -Wextra -Werror   -o CMakeFiles/soln.dir/src/Source.cpp.o -c ../src/Source.cpp\",
+ \"file\": \"../src/Source.cpp\"
+ }
+ ]
+")))
+    (with-non-empty-file
+     (cmake-ide--set-flags-for-file idb (current-buffer))
+     (should (equal-lists flycheck-cppcheck-include-path
+                          '("/usr/include")))
+     )))
+
 (provide 'cmake-ide-test)
 ;;; cmake-ide-test.el ends here

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -329,6 +329,15 @@
     (should (equal (cmake-ide--idb-obj-get real-params 'directory) "/foo/bar/dir"))
     (should (equal (cmake-ide--idb-obj-get fake-params 'directory) nil))))
 
+(ert-deftest test-json-to-file-params-reldir-issue-2 ()
+  (let* ((json-str "[{\"directory\": \"/foo/bar/dir\",
+                      \"command\": \"do the twist\", \"file\": \"foo.cpp\"}]")
+         (idb (cmake-ide--cdb-json-string-to-idb json-str))
+         (real-params (cmake-ide--idb-file-to-obj idb "foo.cpp"))
+         (fake-params (cmake-ide--idb-file-to-obj idb "oops")))
+    (should (equal (cmake-ide--idb-obj-get real-params 'directory) "/foo/bar/dir"))
+    (should (equal (cmake-ide--idb-obj-get fake-params 'directory) nil))))
+
 (ert-deftest test-issue-79 ()
   (let ((cmake-ide-build-dir "/usr/bin")
         (idb (cmake-ide--cdb-json-string-to-idb
@@ -337,6 +346,23 @@
  \"directory\": \"/usr/bin\",
  \"command\": \" g++-6    -I../include   -g -std=c++14 -Wall -Wextra -Werror   -o CMakeFiles/soln.dir/src/Source.cpp.o -c ../src/Source.cpp\",
  \"file\": \"../src/Source.cpp\"
+ }
+ ]
+")))
+    (with-non-empty-file
+     (cmake-ide--set-flags-for-file idb (current-buffer))
+     (should (equal-lists flycheck-cppcheck-include-path
+                          '("/usr/include")))
+     )))
+
+(ert-deftest test-issue-79-2 ()
+  (let ((cmake-ide-build-dir "/usr")
+        (idb (cmake-ide--cdb-json-string-to-idb
+              "[
+ {
+ \"directory\": \"/usr\",
+ \"command\": \" g++-6    -Iinclude   -g -std=c++14 -Wall -Wextra -Werror   -o CMakeFiles/soln.dir/src/Source.cpp.o -c src/Source.cpp\",
+ \"file\": \"src/Source.cpp\"
  }
  ]
 ")))

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -320,5 +320,14 @@
                           '("/usr/local/include" "/usr/local/include/luajit-2.0" "/usr/bin/jansson-2.7/include" "/usr/local/opt/openssl/include" "/usr/local/include/mysql" "/usr/bin" "/usr/lib" "/usr/lib/gsoap" "/usr/lib/http-parser" "/usr/lib/uthash")))
      )))
 
+(ert-deftest test-json-to-file-params-reldir-issue ()
+  (let* ((json-str "[{\"directory\": \"/foo/bar/dir\",
+                      \"command\": \"do the twist\", \"file\": \"./foo.cpp\"}]")
+         (idb (cmake-ide--cdb-json-string-to-idb json-str))
+         (real-params (cmake-ide--idb-file-to-obj idb "./foo.cpp"))
+         (fake-params (cmake-ide--idb-file-to-obj idb "oops")))
+    (should (equal (cmake-ide--idb-obj-get real-params 'directory) "/foo/bar/dir"))
+    (should (equal (cmake-ide--idb-obj-get fake-params 'directory) nil))))
+
 (provide 'cmake-ide-test)
 ;;; cmake-ide-test.el ends here


### PR DESCRIPTION
This fix is to solve the issue which arises when the compile_commands.json uses relative file names which causes `(gethash file idb)` to return nil.

Fix:
Call cmake-ide--relativize before calling gethash

Also added 4 tests to ensure correct working.