### PR TITLE
Added provision to pass misc flags to cmake

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -124,6 +124,12 @@
   :group 'cmake-ide
   :safe #'stringp)
 
+(defcustom cmake-ide-cmake-command-flags
+  nil
+  "List of flags passed to cmake invocation."
+  :group 'cmake-ide
+  :safe #'stringp)
+
 (defcustom cmake-ide-header-search-other-file
   t
   "Whether or not to search for a corresponding source file for headers when setting flags for them."
@@ -559,7 +565,9 @@ the object file's name just above."
   (when project-dir
     (let ((default-directory cmake-dir))
       (cmake-ide--message "Running cmake for src path %s in build path %s" project-dir cmake-dir)
-      (start-process "cmake" "*cmake*" cmake-ide-cmake-command "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" project-dir))))
+      (apply #'start-process "cmake" "*cmake*" cmake-ide-cmake-command project-dir
+	     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" cmake-ide-cmake-command-flags)
+      )))
 
 
 (defun cmake-ide--get-build-dir ()


### PR DESCRIPTION
In invoking cmake from emacs, previously there was no provision to pass flags to cmake. For example, it was not possible to specify the build type or install prefix, etc.
The current commit replaces the `(start-process "cmake" ...)` call with `(apply #'start-process "cmake" ...)` and defines a list, `cmake-ide-cmake-command-flags` which is initialized to nil and may be set in .dir-locals.el.

example (in .dir-locals.el):
`((nil . ((cmake-ide-project-dir . "path/to/project")  
	 (cmake-ide-build-dir . "path/to/build")  
	 (cmake-ide-make-command . "make install")  
	 (cmake-ide-cmake-command-flags . ("-DCMAKE_INSTALL_PREFIX=/path/to/install" "-DCMAKE_BUILD_TYPE=Debug")))))`