### PR TITLE
Avoid noisy Entering/Leaving directory messages

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -107,7 +107,7 @@
   :safe #'stringp)
 
 (defcustom cmake-ide-make-command
-  "make"
+  "make --no-print-directory"
   "The command used to execute Makefile builds."
   :group 'cmake-ide
   :safe #'stringp)


### PR DESCRIPTION
Running make where the CWD isn't the make dir (from the `-C` argument), causes cmake to flood the output with redundant directory changing messages.

Use  `--no-print-directory` to avoid this.