### PR TITLE
Add support for setting flycheck-cppcheck-standards variable.

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -138,6 +138,18 @@
   :type 'booleanp
   :safe #'booleanp)
 
+(defcustom cmake-ide-flycheck-cppcheck-strict-standards
+  nil
+  "Whether or not to be strict when setting cppcheck standards for flycheck.
+If 't' or otherwise non-nil, the flycheck-cppcheck-standards
+variable will only be set to contain standards that exactly match
+those from the compile database.  (If there are none, it will not
+be modified.)  If 'nil', standards will be gracefully degraded to
+the closest possible matches available in cppcheck."
+  :group 'cmake-ide
+  :type 'booleanp
+  :safe #'booleanp)
+
 ;;; The buffers to set variables for
 (defvar cmake-ide--src-buffers nil)
 (defvar cmake-ide--hdr-buffers nil)
@@ -527,7 +539,14 @@ the object file's name just above."
           (make-local-variable 'flycheck-clang-language-standard)
           (let* ((stds (cmake-ide--filter (lambda (x) (string-match std-regex x)) flags))
                  (repls (mapcar (lambda (x) (replace-regexp-in-string std-regex "" x)) stds)))
-            (when repls (setq flycheck-clang-language-standard (car repls))))
+            (when repls
+              (setq flycheck-clang-language-standard (car repls))
+              (unless cmake-ide-flycheck-cppcheck-strict-standards
+                (setq repls (mapcar 'cmake-ide--cmake-standard-to-cppcheck-standard repls)))
+              (setq repls (cmake-ide--filter 'cmake-ide--valid-cppcheck-standard-p repls))
+              (when repls
+                (make-local-variable 'flycheck-cppcheck-standards)
+                (setq flycheck-cppcheck-standards repls))))
 
           (make-local-variable 'flycheck-cppcheck-include-path)
           (setq flycheck-cppcheck-include-path (append sys-includes (cmake-ide--flags-to-include-paths flags))))
@@ -918,10 +937,7 @@ the object file's name just above."
   "Compile the project."
   (interactive)
   (if (cmake-ide--build-dir-var)
-      (let ((command-for-compile (cmake-ide--get-compile-command (cmake-ide--build-dir-var))))
-        (if (functionp command-for-compile)
-            (funcall command-for-compile)
-          (compile command-for-compile)))
+      (compile (cmake-ide--get-compile-command (cmake-ide--build-dir-var)))
     (let ((command (read-from-minibuffer "Compiler command: " compile-command)))
       (compile command)))
   (cmake-ide--run-rc))
@@ -966,6 +982,33 @@ the object file's name just above."
   (when name
     (string-match regexp name)))
 
+(defun cmake-ide--valid-cppcheck-standard-p (standard)
+  "If STANDARD is supported by cppcheck."
+  (cond
+   ((equal standard "posix"))
+   ((equal standard "c89"))
+   ((equal standard "c99"))
+   ((equal standard "c11"))
+   ((equal standard "c++03"))
+   ((equal standard "c++11"))))
+
+(defun cmake-ide--cmake-standard-to-cppcheck-standard (standard)
+  "Convert a CMake language STANDARD to the closest supported by cppcheck.
+If there is no clear and sensible conversion, the input is
+returned unchanged."
+  (let ((gnu-replaced (replace-regexp-in-string "gnu" "c" standard)))
+    (cond
+     ;; Convert "close-enough" matches.
+     ((equal gnu-replaced "c90") "c89")
+     ((equal gnu-replaced "c++98") "c++03")
+     ((equal gnu-replaced "c++14") "c++11")
+     ((equal gnu-replaced "c++1y") "c++11")
+     ((equal gnu-replaced "c++17") "c++11")
+     ((equal gnu-replaced "c++1z") "c++11")
+     ;; See if what we have matches cppcheck's capabilities exactly.
+     ((cmake-ide--valid-cppcheck-standard-p gnu-replaced) gnu-replaced)
+     ;; Otherwise, just hand back the original input.
+     (t standard))))
 
 (provide 'cmake-ide)
 ;;; cmake-ide.el ends here


### PR DESCRIPTION
cmake-ide does not currently provide any information to cppchecker regarding the language standard of a source file. This pull request adds functionality to deduce the standard used to compile a source file under CMake, and pass that information on to cppcheck, through the `flycheck-cppcheck-standards` variable.

The CMake variables `CMAKE_C_STANDARD` and `CMAKE_CXX_STANDARD` can be used to specify standards at the project level, and `C_STANDARD` and `CXX_STANDARD` at the target level. As far as I can tell, this information is not emitted directly by CMake to a `compile_commands.json` file; however, the compile flags in that file do provide this information indirectly. cmake-ide already uses this to set the `flycheck-clang-language-standard` variable, by matching against and then stripping the string `-std=` from entries in a list of compile flags.

One slight complicating factor is that cppcheck only accepts a subset of the standards accepted by clang and gcc, specifically c89, c99, c11, c++03, and c++11. Recent versions (at least >= 3.8.1) of CMake support c90, c99, c11, c++98, c++11, c++14, and c++17. Also, when using GCC or Clang on Linux and OS X (and possibly under other compilers and/or on other OSes), CMake actually emits compile commands specifying GNU variants of standards, e.g. gnu99 and gnu++11.

Of course, there are other ways for `-std=*` flags to get into the compile database. The most likely is someone simply setting the compile flags themselves, rather than using CMake properties.

My logic goes as follow:

- I assume that the vast majority of gnu-dialect-compiled files can safely be checked with the equivalent standard dialect; that is, for example, most files that CMake would compile with gnu++11 can probably be safely run through cppcheck under c++11. (I've always thought it was a bit weird that CMake doesn't allow one to explicitly rule out the use of GNU extensions, but I would hazard a guess that most people aren't in the grey area between the two.)

- It probably doesn't matter to the user if almost-equivalent standards are used. In particular, c89 and c90 are effectively identical, and I don't imagine there are many cases where a user compiling under c++98 would be tripped up by running cppcheck under c++03. I've considered the members of these two pairs to be interchangeable.

- Nevertheless, there are probably cases where a user absolutely doesn't want a standard passed to cppcheck unless it was exactly that used during compilation. For this, I've introduced a `cmake-ide-flycheck-cpp-strict-standards` customisable switch; when set 't', if a standard flag in the compile database cannot be matched exactly to cppcheck-compatible flag, the flycheck-cppcheck-standards variable will not be touched at all. (In other words, the current behaviour.) Users can then set it themselves, if they so desire.

I've tested this on Linux (Ubuntu 16.04 LTS) and OS X (El Capitan), and it seems to work as intended. I have not been able to test this on a Windows machine, but I don't see any reason for it to fail.