### PR TITLE
Add support for setting flycheck-cppcheck-standards variable.

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -1004,6 +1004,7 @@ returned unchanged."
      ;; Convert "close-enough" matches.
      ((equal gnu-replaced "c90") "c89")
      ((equal gnu-replaced "c++98") "c++03")
+     ((equal gnu-replaced "c++0x") "c++03")
      ((equal gnu-replaced "c++14") "c++11")
      ((equal gnu-replaced "c++1y") "c++11")
      ((equal gnu-replaced "c++17") "c++11")

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -987,13 +987,7 @@ the object file's name just above."
 
 (defun cmake-ide--valid-cppcheck-standard-p (standard)
   "If STANDARD is supported by cppcheck."
-  (cond
-   ((equal standard "posix"))
-   ((equal standard "c89"))
-   ((equal standard "c99"))
-   ((equal standard "c11"))
-   ((equal standard "c++03"))
-   ((equal standard "c++11"))))
+  (member standard '("posix" "c89" "c99" "c11" "c++03" "c++11")))
 
 (defun cmake-ide--cmake-standard-to-cppcheck-standard (standard)
   "Convert a CMake language STANDARD to the closest supported by cppcheck.

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -372,5 +372,76 @@
                           '("/usr/include")))
      )))
 
+(ert-deftest test-cmake-ide--valid-cppcheck-standard-p ()
+  "Check that cmake-ide--valid-cppcheck-standard-p behaves as expected."
+  (let ((valid-standards '("posix" "c89" "c99" "c11" "c++03" "c++11"))
+        (invalid-standards '("c90" "c94" "c++98"
+                             "c++0x" "c++1y" "c++1z"
+                             "c++14" "c++17"
+                             "foo" "bar" "baz" "")))
+    ;; Check that valid standards satisfy the predicate.
+    (mapc
+     (lambda (candidate) (should (cmake-ide--valid-cppcheck-standard-p candidate)))
+     valid-standards)
+    ;; Check that invalid standards don't.
+    (mapc
+     (lambda (candidate) (should-not (cmake-ide--valid-cppcheck-standard-p candidate)))
+     invalid-standards)))
+
+(ert-deftest test-cmake-ide--cmake-standard-to-cppcheck-standard ()
+  "Check that cmake-ide--cmake-standard-to-cppcheck-standard behaves as expected."
+  (let ((valid-standards '("posix" "c89" "c99" "c11" "c++03" "c++11"))
+        (convertible-standards '("c90" "c++98" "c++0x" "c++1y" "c++1z" "c++14" "c++17"
+                                 "gnu90" "gnu99" "gnu11"
+                                 "gnu++98" "gnu++03" "gnu++11" "gnu++14" "gnu++17"
+                                 "gnu++0x" "gnu++1y" "gnu++1z"))
+        (expected-conversions '("c89" "c++03" "c++03" "c++11" "c++11" "c++11" "c++11"
+                                "c89" "c99" "c11"
+                                "c++03" "c++03" "c++11" "c++11" "c++11"
+                                "c++03" "c++11" "c++11"))
+        (inconvertible-standards '("foo" "bar" "baz" "iso199009")))
+    ;; Valid standards should be left unchanged.
+    (mapc
+     (lambda (candidate) (should (equal (cmake-ide--cmake-standard-to-cppcheck-standard candidate) candidate)))
+     valid-standards)
+    ;; Invalid but convertible standards should become valid, and be
+    ;; converted to an expected cppcheck-compatible standard.
+    (let ((conversions (mapcar 'cmake-ide--cmake-standard-to-cppcheck-standard convertible-standards)))
+      (mapc (lambda (conversion) (should (cmake-ide--valid-cppcheck-standard-p conversion))) conversions)
+      (should (equal expected-conversions conversions)))
+    ;; Invalid and unconvertible standards should be left unchanged.
+    (let ((bad-conversions (mapcar 'cmake-ide--cmake-standard-to-cppcheck-standard inconvertible-standards)))
+      (should (equal inconvertible-standards bad-conversions)))))
+
+(ert-deftest test-cmake-ide-set-compiler-flags-sets-flycheck-cppcheck-standards ()
+  "Check that cmake-ide-set-compiler-flags sets flycheck-cppcheck-standards as expected."
+  (let ((saved-strict-standards cmake-ide-flycheck-cppcheck-strict-standards))
+    (unwind-protect
+        (with-non-empty-file
+         ;; If strict-standards is on, then passing a set of compiler
+         ;; flags with a cppcheck-invalid -std=* entry should leave
+         ;; the flycheck-cppcheck-standards variable untouched.
+         (setq cmake-ide-flycheck-cppcheck-strict-standards t)
+         (let ((original-standards flycheck-cppcheck-standards))
+           (cmake-ide-set-compiler-flags (current-buffer) '("-std=gnu++98") () ())
+           (should (equal flycheck-cppcheck-standards original-standards)))
+
+         ;; Passing a flag representing a cppcheck-valid standard
+         ;; should produce a change, though.
+         (cmake-ide-set-compiler-flags (current-buffer) '("-std=c++03") () ())
+         (should (equal flycheck-cppcheck-standards '("c++03")))
+
+         ;; If strict standards are turned off, then passing a
+         ;; convertible standard in the flags should produce a change
+         ;; as well.
+         (setq cmake-ide-flycheck-cppcheck-strict-standards nil)
+         (cmake-ide-set-compiler-flags (current-buffer) '("-std=gnu++98") () ())
+         (should (equal flycheck-cppcheck-standards '("c++03")))
+         (cmake-ide-set-compiler-flags (current-buffer) '("-std=c89") () ())
+         (should (equal flycheck-cppcheck-standards '("c89")))))
+
+      ;; Restore pre-test state.
+      (setq cmake-ide-flycheck-cppcheck-strict-standards saved-strict-standards)))
+
 (provide 'cmake-ide-test)
 ;;; cmake-ide-test.el ends here


### PR DESCRIPTION
(Resubmission of [this pull request](https://github.com/atilaneves/cmake-ide/pull/106), but changed to respect the recent upstream commits. Sorry for the confusion.)

cmake-ide does not currently provide any information to cppchecker regarding the language standard of a source file. This pull request adds functionality to deduce the standard used to compile a source file under CMake, and pass that information on to cppcheck, through the `flycheck-cppcheck-standards` variable.

The CMake variables `CMAKE_C_STANDARD` and `CMAKE_CXX_STANDARD` can be used to specify standards at the project level, and `C_STANDARD` and `CXX_STANDARD` at the target level. As far as I can tell, this information is not emitted directly by CMake to a `compile_commands.json` file; however, the compile flags in that file do provide this information indirectly. cmake-ide already uses this to set the `flycheck-clang-language-standard` variable, by matching against and then stripping the string `-std=` from entries in a list of compile flags.

One slight complicating factor is that cppcheck only accepts a subset of the standards accepted by clang and gcc, specifically c89, c99, c11, c++03, and c++11. Recent versions (at least >= 3.8.1) of CMake support c90, c99, c11, c++98, c++11, c++14, and c++17. Also, when using GCC or Clang on Linux and OS X (and possibly under other compilers and/or on other OSes), CMake actually emits compile commands specifying GNU variants of standards, e.g. gnu99 and gnu++11.

Of course, there are other ways for `-std=*` flags to get into the compile database. The most likely is someone simply setting the compile flags themselves, rather than using CMake properties.

My logic goes as follow:

- I assume that the vast majority of gnu-dialect-compiled files can safely be checked with the equivalent standard dialect; that is, for example, most files that CMake would compile with gnu++11 can probably be safely run through cppcheck under c++11. (I've always thought it was a bit weird that CMake doesn't allow one to explicitly rule out the use of GNU extensions, but I would hazard a guess that most people aren't in the grey area between the two.)

- It probably doesn't matter to the user if almost-equivalent standards are used. In particular, c89 and c90 are effectively identical, and I don't imagine there are many cases where a user compiling under c++98 would be tripped up by running cppcheck under c++03. I've considered the members of these two pairs to be interchangeable.

- Nevertheless, there are probably cases where a user absolutely doesn't want a standard passed to cppcheck unless it was exactly that used during compilation. For this, I've introduced a `cmake-ide-flycheck-cpp-strict-standards` customisable switch; when set 't', if a standard flag in the compile database cannot be matched exactly to cppcheck-compatible flag, the flycheck-cppcheck-standards variable will not be touched at all. (In other words, the current behaviour.) Users can then set it themselves, if they so desire.

I've tested this on Linux (Ubuntu 16.04 LTS) and OS X (El Capitan), and it seems to work as intended. I have not been able to test this on a Windows machine, but I don't see any reason for it to fail.