### PR TITLE
Fix bad insertion of sys-includes into company-c-headers-path-system.

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,4 +7,5 @@
  (depends-on "ert-runner")
  (depends-on "auto-complete-clang")
  (depends-on "company")
+ (depends-on "company-c-headers")
  (depends-on "flycheck"))

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -492,7 +492,8 @@ the object file's name just above."
         (make-local-variable 'company-c-headers-path-user)
         (setq company-c-headers-path-user (cmake-ide--flags-to-include-paths flags))
         (make-local-variable 'company-c-headers-path-system)
-        (when sys-includes (add-to-list 'company-c-headers-path-system sys-includes)))
+        (when sys-includes
+          (setq company-c-headers-path-system (append sys-includes company-c-headers-path-system))))
 
       (when (and (featurep 'irony) (not (gethash (cmake-ide--get-build-dir) cmake-ide--irony)))
         (irony-cdb-json-add-compile-commands-path (cmake-ide--locate-project-dir) (cmake-ide--comp-db-file-name))

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -34,6 +34,7 @@
 (require 'cl)
 (require 'auto-complete-clang)
 (require 'company)
+(require 'company-c-headers)
 (require 'flycheck)
 
 (defun equal-lists (lst1 lst2)
@@ -371,6 +372,20 @@
      (should (equal-lists flycheck-cppcheck-include-path
                           '("/usr/include")))
      )))
+
+(ert-deftest test-issue-108 ()
+  "Check that company-c-headers is set correctly by cmake-ide-set-compiler-flags.
+This is a regression test for Issue #108 on github. Previously,
+after a call to cmake-ide-set-compiler-flags, the
+company-c-headers-path-system variable would have the provided
+list of sys-includes consed on the front, causing
+company-c-headers to break."
+  (with-non-empty-file
+   (let ((old-company-c-headers-path-system company-c-headers-path-system))
+     (cmake-ide-set-compiler-flags (current-buffer) () () '("/foo" "/bar"))
+     (should (equal
+              (append '("/foo" "/bar") old-company-c-headers-path-system)
+              company-c-headers-path-system)))))
 
 (provide 'cmake-ide-test)
 ;;; cmake-ide-test.el ends here


### PR DESCRIPTION
This is a bug fix for Issue #108 on github. Previously, after a call
to cmake-ide-set-compiler-flags, the company-c-headers-path-system
variable would have the provided list of sys-includes consed on the
front as a nested list, causing company-c-headers to break. This
commit changes behaviour such that company-c-headers is modified to
simply append the sys-includes instead.

A regression test for this fix is included in the commit. Also, the
Cask file is updated to indicate a dependency on company-c-headers,
and cmake-ide-test.el now requires the same package.