### PR TITLE
Check for nil string when removing compiler command

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -637,10 +637,11 @@ the object file's name just above."
 
 (defun cmake-ide--remove-compiler-from-args (str)
   "Remove the compiler command from STR, leaving only arguments."
-  (let ((args (split-string str " +")))
-    (if (string-suffix-p "ccache" (car args))
-        (cddr args)
-      (cdr args))))
+  (when str
+    (let ((args (split-string str " +")))
+      (if (string-suffix-p "ccache" (car args))
+          (cddr args)
+        (cdr args)))))
 
 (defun cmake-ide--filter-ac-flags (flags)
   "Filter unwanted compiler arguments out from FLAGS."


### PR DESCRIPTION
I tried cmake-ide with a minimal project (without cmake, using bear to create `compiler_commands.json` and `.dir-locals.el` to set build and project dirs) but I kept getting an error when it tried to split a nil string in this function. I haven't bothered trying to figure out why it's being called like this but this is an easy fix to make it work properly.

Here's a backtrace if you have any ideas:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  string-match(" +" nil 0)
  split-string(nil " +")
  cmake-ide--remove-compiler-from-args(nil)
  mapcar(cmake-ide--remove-compiler-from-args (nil))
  cmake-ide--commands-to-hdr-flags((nil))
  cmake-ide--set-flags-for-file(#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("demo.c" (((arguments . ["cc" "-c" "-g" "-o" "demo" "demo.c"]) (directory . "/home/joonatan/tmp/make_demo") (file . "demo.c"))) ...)) #<buffer demo.c>)
  #[257 "\301\300\"\207" [#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("demo.c" (((arguments . ["cc" "-c" "-g" "-o" "demo" "demo.c"]) (directory . "/home/joonatan/tmp/make_demo") (file . "demo.c"))) ...)) cmake-ide--set-flags-for-file] 4 "\n\n(fn X)"](#<buffer demo.c>)
  mapc(#[257 "\301\300\"\207" [#s(hash-table size 65 test equal rehash-size 1.5 rehash-threshold 0.8 data ("demo.c" (((arguments . ["cc" "-c" "-g" "-o" "demo" "demo.c"]) (directory . "/home/joonatan/tmp/make_demo") (file . "demo.c"))) ...)) cmake-ide--set-flags-for-file] 4 "\n\n(fn X)"] (#<buffer demo.c> #<killed buffer>))
  cmake-ide--on-cmake-finished()
  cmake-ide-maybe-run-cmake()
  run-hooks(find-file-hook)
  after-find-file(nil t)
  find-file-noselect-1(#<buffer demo.c> "~/tmp/make_demo/demo.c" nil nil "~/tmp/make_demo/demo.c" (2761754 66306))
  find-file-noselect("/home/joonatan/tmp/make_demo/demo.c" nil nil nil)
  find-file("/home/joonatan/tmp/make_demo/demo.c")
  #[257 "\304\305!!r\306\307\310\311\312!\313\"\314$\216\315@\316\"\210	\205 \317\n!?\205$ \320\321\n\"!+\207" [ivy-last counsel-find-file-speedup-remote ivy--directory find-file-hook internal--before-with-selected-window ivy--get-window make-byte-code 0 "\301\300!\207" vconcat vector [internal--after-with-selected-window] 2 select-window norecord file-remote-p find-file expand-file-name] 8 "\n\n(fn X)"]("/home/joonatan/tmp/make_demo/demo.c")
  ivy-call()
  ivy-read("Find file: " read-file-name-internal :matcher counsel--find-file-matcher :initial-input nil :action #[257 "\304\305!!r\306\307\310\311\312!\313\"\314$\216\315@\316\"\210	\205 \317\n!?\205$ \320\321\n\"!+\207" [ivy-last counsel-find-file-speedup-remote ivy--directory find-file-hook internal--before-with-selected-window ivy--get-window make-byte-code 0 "\301\300!\207" vconcat vector [internal--after-with-selected-window] 2 select-window norecord file-remote-p find-file expand-file-name] 8 "\n\n(fn X)"] :preselect nil :require-match confirm-after-completion :history file-name-history :keymap (keymap (C-backspace . counsel-up-directory) (67108991 . counsel-up-directory)) :caller counsel-find-file)
  counsel-find-file()
  funcall-interactively(counsel-find-file)
  call-interactively(counsel-find-file nil nil)
  command-execute(counsel-find-file)
```