### PR TITLE
Fix missing dependency on s.el

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -4,7 +4,7 @@
 
 ;; Author:  Atila Neves <atila.neves@gmail.com>
 ;; Version: 0.6
-;; Package-Requires: ((emacs "24.1") (cl-lib "0.5") (seq "1.11") (levenshtein "0"))
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.5") (seq "1.11") (levenshtein "0") (s "1.11.0"))
 ;; Keywords: languages
 ;; URL: http://github.com/atilaneves/cmake-ide
 
@@ -44,6 +44,7 @@
 (require 'levenshtein)
 (require 'cl-lib)
 (require 'seq)
+(require 's)
 
 (declare-function rtags-call-rc "rtags")
 


### PR DESCRIPTION
I got the following error message when I open files in a CMake project.

    Symbol’s function definition is void: s-join

The error was caused by lack of `(require 's)`.

I also updated `Package-Requires`in order to add the dependency on s.el.