### PR TITLE
Accept relative cmake-ide-build-dir

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -650,9 +650,10 @@ the object file's name just above."
 (defun cmake-ide--get-build-dir ()
   "Return the directory name to run CMake in."
   ;; build the directory key for the project
-  (let ((build-dir (cmake-ide--build-dir-var)))
-    (when (not build-dir)
-      (setq build-dir (cmake-ide--get-build-dir-from-hash)))
+  (let ((build-dir
+         (expand-file-name (or (cmake-ide--build-dir-var)
+                               (cmake-ide--get-build-dir-from-hash))
+                           (cmake-ide--locate-project-dir))))
     (when (not (file-accessible-directory-p build-dir))
       (cmake-ide--message "Making directory %s" build-dir)
       (make-directory build-dir))


### PR DESCRIPTION
If cmake-ide-build-dir is a relative path treat it
as relative to the project-dir.

I hope this is a valid fix for Issue #137.  Seems to fix my concerns, at least.
