### PR TITLE
Project key refactoring (work in progress)

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -46,6 +46,15 @@
 (require 'seq)
 (require 's)
 
+(defsubst cmake-ide--string-empty-p (string)
+  "Check whether STRING is empty."
+  (string= string ""))
+
+(when (not (require 'subr-x nil t))
+  (message "`subr-x' not found")
+  (fset 'string-empty-p 'cmake-ide--string-empty-p)
+  )
+
 (declare-function rtags-call-rc "rtags")
 
 (defcustom cmake-ide-flags-c
@@ -313,6 +322,7 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
   "Set compiler flags for all buffers that requested it."
   (let* ((idb (cmake-ide--cdb-json-file-to-idb))
          (set-flags (lambda (x) (cmake-ide--set-flags-for-file idb x))))
+    (cmake-ide--message "on-cmake-finished [%s]" idb)
     (mapc set-flags cmake-ide--src-buffers)
     (mapc set-flags cmake-ide--hdr-buffers)
     (setq cmake-ide--src-buffers nil cmake-ide--hdr-buffers nil)
@@ -904,7 +914,7 @@ the object file's name just above."
 (defun cmake-ide--locate-cmakelists-impl (dir last-found)
   "Find the topmost CMakeLists.txt from DIR using LAST-FOUND as a 'plan B'."
   (let ((new-dir (locate-dominating-file dir "CMakeLists.txt")))
-    (cmake-ide--message "locate cmakelists new-dir [%s]" new-dir)
+;    (cmake-ide--message "locate cmakelists new-dir [%s]" new-dir)
     (if new-dir
         (cmake-ide--locate-cmakelists-impl (expand-file-name ".." new-dir) new-dir)
       last-found)))

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -305,7 +305,7 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
 	      (let ((default-directory cmake-dir))
 		(cmake-ide--run-cmake-impl project-dir cmake-dir)
 		(cmake-ide--register-callback))))
-	(cmake-ide-message "try to run cmake on a non cmake project [%s]" default-directory)
+	(cmake-ide--message "try to run cmake on a non cmake project [%s]" default-directory)
 	)))))
 
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -299,7 +299,6 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
       (when project-dir ; no point if it's not a CMake project
         ;; register this buffer to be either a header or source file
         ;; waiting for results
-;	(cmake-ide--message "Found project dir %s" project-dir)
         (cmake-ide--add-file-to-buffer-list)
         (let ((cmake-dir (cmake-ide--get-build-dir)))
           (let ((default-directory cmake-dir))
@@ -322,7 +321,6 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
   "Set compiler flags for all buffers that requested it."
   (let* ((idb (cmake-ide--cdb-json-file-to-idb))
          (set-flags (lambda (x) (cmake-ide--set-flags-for-file idb x))))
-;    (cmake-ide--message "on-cmake-finished [%s]" idb)
     (mapc set-flags cmake-ide--src-buffers)
     (mapc set-flags cmake-ide--hdr-buffers)
     (setq cmake-ide--src-buffers nil cmake-ide--hdr-buffers nil)
@@ -660,7 +658,6 @@ the object file's name just above."
             (setq build-dir (expand-file-name build-directory-name build-parent-directory)
                   )
 	    (progn
-;	      (cmake-ide--message "puthash for %s %s" project-key build-dir)
 	      (puthash project-key build-dir cmake-ide--cmake-hash)
 	      )
             build-dir)
@@ -912,7 +909,6 @@ the object file's name just above."
 (defun cmake-ide--locate-cmakelists-impl (dir last-found)
   "Find the topmost CMakeLists.txt from DIR using LAST-FOUND as a 'plan B'."
   (let ((new-dir (locate-dominating-file dir "CMakeLists.txt")))
-;    (cmake-ide--message "locate cmakelists new-dir [%s]" new-dir)
     (if new-dir
         (cmake-ide--locate-cmakelists-impl (expand-file-name ".." new-dir) new-dir)
       last-found)))
@@ -920,7 +916,6 @@ the object file's name just above."
 (defun cmake-ide--locate-project-dir ()
   "Return the path to the project directory."
   (let ((cmakelists (cmake-ide--locate-cmakelists)))
-    (cmake-ide--message "locate-project-dir : [%s][%s]" (cmake-ide--project-dir-var) cmakelists)
     (or (and (cmake-ide--project-dir-var) (expand-file-name (cmake-ide--project-dir-var)))
         (and cmakelists (file-name-directory cmakelists))
 	(and (cmake-ide--message "Current project is not a cmake project") nil) ; if no CMakeLists.txt nor project-dir set,return nil and prevent cmake-ide to do anything else

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -649,7 +649,6 @@ the object file's name just above."
 (defun cmake-ide--get-build-dir-from-hash ()
   "Get dir form hash table, if not present compute a build dir and insert it in the table.  For non cmake project, insert and use a nil entry (associated temp directory)."
   (let ((project-key (cmake-ide--get-project-key)))
-;    (when project-key
     (let ((build-dir (gethash project-key cmake-ide--cmake-hash nil)))
       (if (not build-dir)
           (let ((build-parent-directory (or cmake-ide-build-pool-dir temporary-file-directory))
@@ -661,7 +660,6 @@ the object file's name just above."
             (setq build-dir (expand-file-name build-directory-name build-parent-directory)
                   )
 	    (progn
-;	      (cmake-ide--message "Key [%s] Add dir %s" project-key build-dir)
 	      (puthash project-key build-dir cmake-ide--cmake-hash)
 	      )
             build-dir)

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -198,7 +198,7 @@ the closest possible matches available in cppcheck."
 
 (defcustom cmake-ide-cmakelists-dir
   nil
-  "The directory where the main CMakelists.txt is.  DEPRACATED use cmake-ide-projet-dir instead."
+  "The directory where the main CMakelists.txt is.  DEPRECATED use cmake-ide-projet-dir instead."
   :group 'cmake-ide
   :type 'file)
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -299,7 +299,7 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
       (when project-dir ; no point if it's not a CMake project
         ;; register this buffer to be either a header or source file
         ;; waiting for results
-	(cmake-ide--message "Found project dir %s" project-dir)
+;	(cmake-ide--message "Found project dir %s" project-dir)
         (cmake-ide--add-file-to-buffer-list)
         (let ((cmake-dir (cmake-ide--get-build-dir)))
           (let ((default-directory cmake-dir))
@@ -322,7 +322,7 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
   "Set compiler flags for all buffers that requested it."
   (let* ((idb (cmake-ide--cdb-json-file-to-idb))
          (set-flags (lambda (x) (cmake-ide--set-flags-for-file idb x))))
-    (cmake-ide--message "on-cmake-finished [%s]" idb)
+;    (cmake-ide--message "on-cmake-finished [%s]" idb)
     (mapc set-flags cmake-ide--src-buffers)
     (mapc set-flags cmake-ide--hdr-buffers)
     (setq cmake-ide--src-buffers nil cmake-ide--hdr-buffers nil)
@@ -636,12 +636,12 @@ the object file's name just above."
 
 
 (defun cmake-ide--get-project-key ()
-  "Return the Project Key to store this directory in the hash map.  It is build from the concatenation of project-dir and cmake-opts."
+  "Return the Project Key to store this directory in the hash map.  It corresponds to the concatenation of project-dir and cmake-opts."
   (let ((project-dir (cmake-ide--locate-project-dir)))
     (if project-dir
 	(replace-regexp-in-string "[-/= ]" "_"  (concat (expand-file-name project-dir)
 							cmake-ide-cmake-opts))
-      (cmake-ide--message "Not a cmake project")
+      (cmake-ide--message "Could not get project key, this is not a cmake project")
       ))
     )
 
@@ -660,7 +660,7 @@ the object file's name just above."
             (setq build-dir (expand-file-name build-directory-name build-parent-directory)
                   )
 	    (progn
-	      (cmake-ide--message "puthash for %s %s" project-key build-dir)
+;	      (cmake-ide--message "puthash for %s %s" project-key build-dir)
 	      (puthash project-key build-dir cmake-ide--cmake-hash)
 	      )
             build-dir)
@@ -677,7 +677,6 @@ the object file's name just above."
     (when (not (file-accessible-directory-p build-dir))
       (cmake-ide--message "Making directory %s" build-dir)
       (make-directory build-dir))
-;;    (setq cmake-ide-build-dir build-dir)
     (file-name-as-directory build-dir)))
 
 
@@ -899,7 +898,6 @@ the object file's name just above."
   (if (boundp sym) (symbol-value sym) nil))
 
 
-;bug here ? since (expand-file-name "test" nil) eval to default-directory/test
 (defun cmake-ide--locate-cmakelists ()
   "Find the topmost CMakeLists.txt file."
   (if (cmake-ide--project-dir-var)

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -537,6 +537,26 @@ company-c-headers to break."
      (cmake-ide--set-flags-for-file idb (current-buffer))
      (should (equal flycheck-clang-args '("-Wall" "-Wextra" "-pedantic" "-c"))))))
 
+(ert-deftest test-project-key-basic ()
+  (setq cmake-ide-build-dir nil cmake-ide-dir nil)
+  (setq cmake-ide--cmake-hash (make-hash-table :test #'equal))
+  (setq cmake-ide-project-dir "./test1")
+					; two run of get-project-key have to return the same result
+  (let ((dir1 (cmake-ide--get-project-key))
+        (dir2 (cmake-ide--get-project-key)))
+    (should (equal dir1 dir2)))
+  (let ((dir1 (cmake-ide--get-project-key)))
+    (setq cmake-ide-project-dir "./test2")
+					; since project-key depend on project-dir, two different dir must have different value
+    (let ((dir2 (cmake-ide--get-project-key)))
+      (should (not (equal dir1 dir2)))))
+  (let ((dir1 (cmake-ide--get-project-key)))
+    (setq cmake-ide-cmake-opts "-DTest")
+    					; since project-key depend on cmake-opts, two different dir must have different value
+    (let ((dir2 (cmake-ide--get-project-key)))
+      (should (not (equal dir1 dir2)))))
+  )
+
 
 (provide 'cmake-ide-test)
 ;;; cmake-ide-test.el ends here


### PR DESCRIPTION
The main idea with `cmake-ide--get-project-key` is to compute a unique "key" for a given project (and `cmake-opts`) to store `build-dir`. The latter could be set using .dir-locals.el, tmp build, or in persitent pool dir.
But I do not want to set `cmake-ide-build-dir` because it will mess up when two projects are open within the same emacs session (without .dir-locals ...)