### PR TITLE
Do not query the user about killing the RDM process

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -1044,9 +1044,12 @@ the object file's name just above."
     (unless (cmake-ide--process-running-p "rdm")
       (let ((buf (get-buffer-create cmake-ide-rdm-buffer-name)))
         (cmake-ide--message "Starting rdm server")
-        (with-current-buffer buf (start-process "rdm" (current-buffer)
-                                                (cmake-ide-rdm-executable)
-                                                "-c" cmake-ide-rdm-rc-path))))))
+        (with-current-buffer buf
+          (let ((rdm-process (start-process "rdm" (current-buffer)
+                                            (cmake-ide-rdm-executable)
+                                            "-c" cmake-ide-rdm-rc-path)))
+            (set-process-query-on-exit-flag rdm-process nil)))))))
+
 
 (defun cmake-ide--process-running-p (name)
   "If a process called NAME is running or not."


### PR DESCRIPTION
This is based on the idea that the RDM process is not a *sensitive* process and thus there is no need to warn the users about it when they kill Emacs.

Of course the above assumption might be completely wrong, if that's the case please explain why.