### PR TITLE
Fix project without cmakelists.txt, with or without compile_commands.json

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -680,12 +680,12 @@ the object file's name just above."
   "Return the directory name to run CMake in."
   ;; build the directory key for the project
   (let ((build-dir
-         (expand-file-name (or (cmake-ide--build-dir-var)
-                               (cmake-ide--get-build-dir-from-hash))
-                           (cmake-ide--locate-project-dir))))
+         (expand-file-name (or (cmake-ide--build-dir-var) ; if use set, use this value
+                               (cmake-ide--get-build-dir-from-hash)) ; else get from project-key
+                           (cmake-ide--locate-project-dir)))) ; if relative, use project-dir as base directory
     (when (not (file-accessible-directory-p build-dir))
       (cmake-ide--message "Making directory %s" build-dir)
-      (make-directory build-dir))
+      (make-directory build-dir 't))
     (file-name-as-directory build-dir)))
 
 
@@ -928,8 +928,8 @@ the object file's name just above."
 (defun cmake-ide--locate-project-dir ()
   "Return the path to the project directory."
   (let ((cmakelists (cmake-ide--locate-cmakelists)))
-    (or (and (cmake-ide--project-dir-var) (expand-file-name (cmake-ide--project-dir-var)))
-        (and cmakelists (file-name-directory cmakelists))
+    (or (and (cmake-ide--project-dir-var) (expand-file-name (cmake-ide--project-dir-var)))     ; if project dir is set by the user, use this value.
+        (and cmakelists (file-name-directory cmakelists)) ; else try to use cmakelists
 	nil ; if no CMakeLists.txt nor project-dir set, return nil and prevent cmake-ide to do anything else
 	    )))
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -304,11 +304,15 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
 	    (progn
 	      (cmake-ide--add-file-to-buffer-list)
 					; run cmake only if project dir contains a CMakeLists.txt file.
-	      (when (file-exists-p (expand-file-name "CMakeList.txt" project-dir))
+	      (if (file-exists-p (expand-file-name "CMakeLists.txt" project-dir))
 		(let ((cmake-dir (cmake-ide--get-build-dir)))
 		  (let ((default-directory cmake-dir))
 		    (cmake-ide--run-cmake-impl project-dir cmake-dir)
-		    (cmake-ide--register-callback)))))
+		    (cmake-ide--register-callback)))
+		(cmake-ide--message "No CMakeLists.txt found in project dir")
+		)
+	      
+	      )
 	  (cmake-ide--message "try to run cmake on a non cmake project [%s]" default-directory)))))
 )
 
@@ -630,7 +634,7 @@ the object file's name just above."
 	      (delete-file filename)
 	      (kill-buffer buffer)
 	      (let ((project-dir (cmake-ide--locate-project-dir)))
-		(when (and project-dir  (file-exists-p (expand-file-name "CMakeList.txt" project-dir)))
+		(when (and project-dir  (file-exists-p (expand-file-name "CMakeLists.txt" project-dir)))
 		  (cmake-ide--run-cmake-impl project-dir (cmake-ide--get-build-dir)))
 		(cmake-ide--message "File '%s' successfully removed" filename)))))
       (error "Not possible to delete a file without setting cmake-ide-build-dir"))))
@@ -1108,7 +1112,7 @@ the object file's name just above."
 					    (cmake-ide-rdm-executable)
 					    "-c" cmake-ide-rdm-rc-path)))
 	    ; add a small delay before going on, since rdm could take some time to be ready to treat rc commands
-	    (sleep-for 0.2)
+	    (sleep-for 0.5)
 	    (set-process-query-on-exit-flag rdm-process nil)))))))
 
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -544,7 +544,7 @@ the object file's name just above."
   "Use IDB to set flags from a header BUFFER with SYS-INCLUDES from all project source files."
   (cmake-ide--message "Could not find suitable src file for %s, using all compiler flags" (buffer-file-name buffer))
   (let* ((all-commands (cmake-ide--idb-all-commands idb))
-         (command (elt all-commands 0))
+					;         (command (elt all-commands 0))
          (hdr-flags (cmake-ide--commands-to-hdr-flags all-commands))
          (hdr-includes (cmake-ide--commands-to-hdr-includes all-commands)))
     (cmake-ide-set-compiler-flags buffer hdr-flags hdr-includes sys-includes)))

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -630,7 +630,8 @@ the object file's name just above."
 	      (delete-file filename)
 	      (kill-buffer buffer)
 	      (let ((project-dir (cmake-ide--locate-project-dir)))
-		(when project-dir (cmake-ide--run-cmake-impl project-dir (cmake-ide--get-build-dir)))
+		(when (and project-dir  (file-exists-p (expand-file-name "CMakeList.txt" project-dir)))
+		  (cmake-ide--run-cmake-impl project-dir (cmake-ide--get-build-dir)))
 		(cmake-ide--message "File '%s' successfully removed" filename)))))
       (error "Not possible to delete a file without setting cmake-ide-build-dir"))))
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -281,7 +281,7 @@ the closest possible matches available in cppcheck."
 
 (defun cmake-ide--comp-db-file-name ()
   "The name of the compilation database file."
-  (when (cmake-ide--locate-project-dir)
+  (when (cmake-ide--get-build-dir)
 	 (expand-file-name "compile_commands.json" (cmake-ide--get-build-dir)))
     )
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -309,7 +309,7 @@ This works by calling cmake in a temporary directory (or cmake-ide-build-dir)
 		  (let ((default-directory cmake-dir))
 		    (cmake-ide--run-cmake-impl project-dir cmake-dir)
 		    (cmake-ide--register-callback)))
-		(cmake-ide--message "No CMakeLists.txt found in project dir")
+		(cmake-ide--message "No CMakeLists.txt found in project dir, skip cmake run.")
 		)
 	      
 	      )

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -544,7 +544,6 @@ the object file's name just above."
   "Use IDB to set flags from a header BUFFER with SYS-INCLUDES from all project source files."
   (cmake-ide--message "Could not find suitable src file for %s, using all compiler flags" (buffer-file-name buffer))
   (let* ((all-commands (cmake-ide--idb-all-commands idb))
-					;         (command (elt all-commands 0))
          (hdr-flags (cmake-ide--commands-to-hdr-flags all-commands))
          (hdr-includes (cmake-ide--commands-to-hdr-includes all-commands)))
     (cmake-ide-set-compiler-flags buffer hdr-flags hdr-includes sys-includes)))
@@ -1106,14 +1105,14 @@ the object file's name just above."
 
     (unless (cmake-ide--process-running-p "rdm")
       (let ((buf (get-buffer-create cmake-ide-rdm-buffer-name)))
-	(cmake-ide--message "Starting rdm server")
-	(with-current-buffer buf
-	  (let ((rdm-process (start-process "rdm" (current-buffer)
-					    (cmake-ide-rdm-executable)
-					    "-c" cmake-ide-rdm-rc-path)))
-	    ; add a small delay before going on, since rdm could take some time to be ready to treat rc commands
-	    (sleep-for 0.5)
-	    (set-process-query-on-exit-flag rdm-process nil)))))))
+        (cmake-ide--message "Starting rdm server")
+        (with-current-buffer buf
+          (let ((rdm-process (start-process "rdm" (current-buffer)
+                                            (cmake-ide-rdm-executable)
+                                            "-c" cmake-ide-rdm-rc-path)))
+            ; add a small delay before going on, since rdm could take some time to be ready to treat rc commands
+            (sleep-for 0.8)
+            (set-process-query-on-exit-flag rdm-process nil)))))))
 
 
 (defun cmake-ide--process-running-p (name)
@@ -1123,8 +1122,8 @@ the object file's name just above."
 (defun cmake-ide--system-process-running-p (name)
   "If a process called NAME is running on the system."
   (let* ((all-args (mapcar (lambda (x) (cdr (assq 'args (process-attributes x)))) (list-system-processes)))
-	 (match-args (cmake-ide--filter (lambda (x) (cmake-ide--string-match (concat "\\b" name "\\b") x)) all-args))
-	 )
+         (match-args (cmake-ide--filter (lambda (x) (cmake-ide--string-match (concat "\\b" name "\\b") x)) all-args))
+         )
     (not (null match-args))))
 
 (defun cmake-ide--string-match (regexp name)

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -220,7 +220,8 @@
 (ert-deftest test-all-vars-ccache-alt ()
   (let ((idb (cmake-ide--cdb-json-string-to-idb
               "[{\"file\": \"file1.c\",
-                  \"command\": \"/usr/lib/ccache/bin/clang++ -Iinc1 -Iinc2 -Dfoo=bar -S -F -g -std=c++14\"}]")))
+                  \"command\": \"/usr/lib/ccache/bin/clang++ -Iinc1 -Iinc2 -Dfoo=bar -S -F -g -std=c++14\"}]"))
+	(cmake-ide-project-dir "/tmp"))
     (with-non-empty-file
      (cmake-ide--set-flags-for-file idb (current-buffer))
      (should (equal-lists ac-clang-flags '("-Iinc1" "-Iinc2" "-Dfoo=bar" "-S" "-F" "-std=c++14"))))))
@@ -503,6 +504,7 @@ company-c-headers to break."
 (ert-deftest test-issue-125 ()
   (setq cmake-ide-build-dir nil cmake-ide-dir nil)
   (setq cmake-ide--cmake-hash (make-hash-table :test #'equal))
+  (setq cmake-ide-project-dir "/tmp")
   (let ((dir1 (cmake-ide--get-build-dir))
         (dir2 (cmake-ide--get-build-dir)))
     (should (equal dir1 dir2))))
@@ -515,7 +517,8 @@ company-c-headers to break."
   \"command\": \"clang++ -Wall -Wextra -std=c++14 -c foo.cpp\",
   \"file\": \"foo.cpp\"
 }
-]")))
+]"))
+	(cmake-ide-build-dir "/tmp"))
     (with-non-empty-file
      (cmake-ide--set-flags-for-file idb (current-buffer))
      (should (equal flycheck-clang-args '("-Wall" "-Wextra" "-c"))))))

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -560,6 +560,28 @@ company-c-headers to break."
       (should (not (equal dir1 dir2)))))
   )
 
+(ert-deftest test-build-dir-behavior ()
+  (setq cmake-ide-build-dir nil cmake-ide-dir nil)
+  (setq cmake-ide--cmake-hash (make-hash-table :test #'equal))
+  (setq cmake-ide-project-dir "./test1")
+  (setq cmake-ide-build-pool-dir nil)
+  (let ((dir1 (cmake-ide--get-build-dir)))
+    (cmake-ide--message "dir 1 %s" dir1))
+
+
+  (setq cmake-ide-build-dir "test-build")
+  (setq cmake-ide--cmake-hash (make-hash-table :test #'equal))
+  (setq cmake-ide-project-dir "./test1")
+  (setq cmake-ide-build-pool-dir nil)
+  (let ((dir1 (cmake-ide--get-build-dir)))
+    (cmake-ide--message "dir 1 %s" dir1))
+  
+  (setq cmake-ide-build-dir "/tmp/test-build")
+  (setq cmake-ide--cmake-hash (make-hash-table :test #'equal))
+  (setq cmake-ide-project-dir "./test1")
+  (let ((dir1 (cmake-ide--get-build-dir)))
+    (cmake-ide--message "dir 1 %s" dir1))
+)
 
 (provide 'cmake-ide-test)
 ;;; cmake-ide-test.el ends here


### PR DESCRIPTION
This PR should be tested, the unit test do not cover all expected behavior. 
I should add unit tests, but I don't know how do define all theses tests.
As far as I can tell, it works for me for several project, with or without build pool dir and persistent naming.
Might fix #150 #149 #143 #139 