### PR TITLE
Fix invalid type definition for custom variable

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -100,7 +100,7 @@
   nil
   "Whether or not to use a persistent naming scheme for all automatically created build directories."
   :group 'cmake-ide
-  :type 'booleanp
+  :type 'boolean
   :safe #'booleanp)
 
 (defcustom cmake-ide-project-dir


### PR DESCRIPTION



When trying to customize this variable:
```
Debugger entered--Lisp error: (void-function nil)
  nil((booleanp) nil)
  widget-apply((booleanp) :match nil)
  custom-variable-value-create((custom-variable :documentation-shown t :custom-state unknown :tag "Cmake Ide Build Pool Use Persistent Naming" :value cmake-ide-build-pool-use-persistent-naming :custom-form edit))
  widget-apply((custom-variable :documentation-shown t :custom-state unknown :tag "Cmake Ide Build Pool Use Persistent Naming" :value cmake-ide-build-pool-use-persistent-naming :custom-form edit) :value-create)
  widget-default-create((custom-variable :documentation-shown t :custom-state unknown :tag "Cmake Ide Build Pool Use Persistent Naming" :value cmake-ide-build-pool-use-persistent-naming :custom-form edit))

```