### PR TITLE
Fix custom default value

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -94,8 +94,8 @@
   )
 
 (defcustom cmake-ide-build-pool-dir
-  nil
-  "The parent directory for all automatically created build directories.  If nil, the system tmp-directory is used."
+  temporary-file-directory
+  "The parent directory for all automatically created build directories."
   :group 'cmake-ide
   :type 'directory
   :safe #'stringp


### PR DESCRIPTION
Can't customize the variable `cmake-ide-build-pool-use-persistent-naming` because of a type-mismatch:

```
Debugger entered--Lisp error: (void-variable ~/BuildDir)
  eval(~/BuildDir)
  custom-variable-set((custom-variable :group (custom-group :documentation-shown t :custom-state 
```