### PR TITLE
Filtering out the '-o <output>' option when defining flycheck-gcc-args

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -616,7 +616,7 @@ the object file's name just above."
           (make-local-variable 'flycheck-clang-args)
           (make-local-variable 'flycheck-gcc-args)
           (setq flycheck-clang-args args)
-          (setq flycheck-gcc-args args)
+          (setq flycheck-gcc-args (cide--filter-output-arg args))
 
           (make-local-variable 'flycheck-clang-language-standard)
           (make-local-variable 'flycheck-gcc-language-standard)
@@ -1170,6 +1170,13 @@ returned unchanged."
      ((cide--valid-cppcheck-standard-p gnu-replaced) gnu-replaced)
      ;; Otherwise, just hand back the original input.
      (t standard))))
+(defun cide--filter-output-arg (args)
+  "Filter out '-o <output>' from the provided 'args' list."
+  (if (not args)
+      nil
+    (if (cide--string-match "^-o" (car args))
+	(nthcdr 2 args) ;; We assume '-o <output>' is provided only once, hence we stop recursion here. 
+      (cons (car args) (cide--filter-output-arg (cdr args))))))
 
 (provide 'cmake-ide)
 ;;; cmake-ide.el ends here

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -545,6 +545,10 @@ company-c-headers to break."
        (cide--set-flags-for-src-file file-params (current-buffer) sys-includes))
      (should (equal flycheck-gcc-args '("-pipe" "-m64" "-g" "-fPIC" "-c"))))))
 
+
+(ert-deftest test-cide--filter-output-arg ()
+  (should (equal (cide--filter-output-arg '("-fPIC" "-o" "output" "-Wall")) '("-fPIC" "-Wall") )))
+
 (ert-deftest test-split-command ()
   (should (equal (cide--split-command "foo \"quux toto\" bar") '("foo" "quux toto" "bar"))))
 

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -529,6 +529,22 @@ company-c-headers to break."
      (cide--set-flags-for-file idb (current-buffer))
      (should (equal flycheck-clang-args '("-Wall" "-Wextra" "-c"))))))
 
+(ert-deftest test-flycheck-gcc-args ()
+  (let ((idb (cide--cdb-json-string-to-idb
+              "[
+{
+  \"directory\": \"\",
+  \"command\": \"/bin/c++ -Dfoo_cpp_EXPORTS -I/usr/local/include -pipe -m64 -std=c++14 -g -fPIC -o CMakeFiles/hello.dir/foo.cpp.o -c foo.cpp\",
+  \"file\": \"foo.cpp\"
+}
+]"))
+        (cmake-ide-build-dir "/tmp"))
+    (with-non-empty-file
+     (let* ((file-params (cide--idb-file-to-obj idb "foo.cpp"))
+	    (sys-includes (cide--params-to-sys-includes file-params)))
+       (cide--set-flags-for-src-file file-params (current-buffer) sys-includes))
+     (should (equal flycheck-gcc-args '("-pipe" "-m64" "-g" "-fPIC" "-c"))))))
+
 (ert-deftest test-split-command ()
   (should (equal (cide--split-command "foo \"quux toto\" bar") '("foo" "quux toto" "bar"))))
 


### PR DESCRIPTION
Please find a possible patch for fixing the double output argument issue for c/c++-gcc flycheck checker.