### PR TITLE
Windows support - Standard MinGW + Clang + CMake (Windows binaries)

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -614,7 +614,7 @@ the object file's name just above."
         (let* ((std-regex "^-std=")
                (include-path (append sys-includes (cide--flags-to-include-paths flags)))
                (definitions (append (cide--get-existing-definitions) (cide--flags-to-defines flags)))
-               (args (cide--filter (lambda (x) (not (string-match std-regex x))) (cide--flags-filtered flags))))
+               (args (cide--filter (lambda (x) (not (string-match std-regex x))) (cide--flags-filtered (cide--get-compiler-flags flags)))))
           (make-local-variable 'flycheck-clang-include-path)
           (make-local-variable 'flycheck-gcc-include-path)
           (setq flycheck-clang-include-path include-path)

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -773,7 +773,7 @@ Return nil for non-CMake project."
 
 (defun cide--get-file-params (response-file)
   "Get file parameters from a response file given as compilation argument."
-  (string-remove-suffix "\n" (cide--get-string-from-file (expand-file-name response-file (cide--get-build-dir)))))
+  (string-remove-suffix "\n" (cide--get-string-from-file (expand-file-name response-file (cide--build-dir-from-cache)))))
 
 (defun cide--replace-params-in-region (obj params begin end)
   "Cut regions from begin to end and place params in it."

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -415,7 +415,7 @@ This works by calling cmake in a temporary directory (or `cmake-ide-build-dir')
 
 (defun cide--get-system-filename (file-name)
   "Get the file name considering case sensitivity of the system."
-  (if (eq system-type 'windows-nt)
+  (if (and file-name (eq system-type 'windows-nt))
       (s-downcase file-name)
     file-name))
 

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -776,7 +776,7 @@ Return nil for non-CMake project."
 
 (defun cide--get-file-params (response-file)
   "Get file parameters from a response file given as compilation argument."
-  (replace-regexp-in-string "\\\n" "" (cide--get-string-from-file (expand-file-name response-file (cide--build-dir-from-cache)))))
+  (replace-regexp-in-string "\\\n" " " (cide--get-string-from-file (expand-file-name response-file (cide--build-dir-from-cache)))))
 
 (defun cide--quote-if-spaces (str)
   "Add quotes to STR if it has spaces."

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -776,7 +776,7 @@ Return nil for non-CMake project."
 
 (defun cide--get-file-params (response-file)
   "Get file parameters from a response file given as compilation argument."
-  (string-remove-suffix "\n" (cide--get-string-from-file (expand-file-name response-file (cide--build-dir-from-cache)))))
+  (replace-regexp-in-string "\\\n" "" (cide--get-string-from-file (expand-file-name response-file (cide--build-dir-from-cache)))))
 
 (defun cide--quote-if-spaces (str)
   "Add quotes to STR if it has spaces."

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -419,7 +419,7 @@ This works by calling cmake in a temporary directory (or `cmake-ide-build-dir')
       (s-downcase file-name)
     file-name))
 
-(defun cmake-ide--set-flags-for-src-file (file-params buffer sys-includes)
+(defun cide--set-flags-for-src-file (file-params buffer sys-includes)
   "Set the compiler flags from FILE-PARAMS for source BUFFER with SYS-INCLUDES."
   (let* ((src-flags (cide--params-to-src-flags file-params))
          (src-includes (cide--params-to-src-includes file-params)))

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -489,7 +489,10 @@ company-c-headers to break."
                   \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]")))
            (file-params (cide--idb-file-to-obj idb "file1")))
       (with-temp-file temporary-filename
-        (insert "-fmessage-length=0 -nostdlib")
+        (insert "-fmessage-length=0")
+        (end-of-line)
+        (newline)
+        (insert "-nostdlib")
         (end-of-line)
         (newline))
       (let ((args (cide--file-params-to-args file-params)))

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -465,6 +465,26 @@ company-c-headers to break."
     (should (equal args '("cmd1" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
   )
 
+
+(ert-deftest test-get-command-args-with-resolve-file ()
+  "Check if resolve file is read in in case it is used by CMake"
+  (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
+         (idb (cide--cdb-json-string-to-idb
+               (concat "[{\"file\": \"file1\",
+                  \"command\": \"cmd1 " "@" temporary-filename " -Ifoo -Ibar -std=c++14 --foo --bar\"},
+                 {\"file\": \"file2\",
+                  \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]")))
+         (file-params (cide--idb-file-to-obj idb "file1")))
+    (with-temp-file temporary-filename
+      (insert "-fmessage-length=0")
+      (end-of-line)
+      (newline))
+    (let ((args (cide--file-params-to-args file-params)))
+      (should (equal args '("cmd1" "-fmessage-length=0" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
+    (delete-file temporary-filename))
+  )
+
+
 (ert-deftest test-get-command-args-with-arguments ()
   "Check getting command arguments from file-params."
   (let* ((idb (cide--cdb-json-string-to-idb
@@ -476,6 +496,7 @@ company-c-headers to break."
          (args (cide--file-params-to-args file-params)))
     (should (equal args '("cmd1" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
   )
+
 
 (ert-deftest test-all-commands ()
   "Check getting command arguments from file-params."

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -468,20 +468,21 @@ company-c-headers to break."
 
 (ert-deftest test-get-command-args-with-resolve-file-in-command ()
   "Check if resolve file is read in in case it is used by CMake in command"
-  (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
-         (idb (cide--cdb-json-string-to-idb
-               (concat "[{\"file\": \"file1\",
+  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+    (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
+           (idb (cide--cdb-json-string-to-idb
+                 (concat "[{\"file\": \"file1\",
                   \"command\": \"cmd1 " "@" temporary-filename " -Ifoo -Ibar -std=c++14 --foo --bar\"},
                  {\"file\": \"file2\",
                   \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]")))
-         (file-params (cide--idb-file-to-obj idb "file1")))
-    (with-temp-file temporary-filename
-      (insert "-fmessage-length=0 -nostdlib")
-      (end-of-line)
-      (newline))
-    (let ((args (cide--file-params-to-args file-params)))
-      (should (equal args '("cmd1" "-fmessage-length=0" "-nostdlib" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
-    (delete-file temporary-filename))
+           (file-params (cide--idb-file-to-obj idb "file1")))
+      (with-temp-file temporary-filename
+        (insert "-fmessage-length=0 -nostdlib")
+        (end-of-line)
+        (newline))
+      (let ((args (cide--file-params-to-args file-params)))
+        (should (equal args '("cmd1" "-fmessage-length=0" "-nostdlib" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
+      (delete-file temporary-filename)))
   )
 
 
@@ -500,18 +501,19 @@ company-c-headers to break."
 
 (ert-deftest test-get-command-args-with-resolve-file-in-arguments ()
   "Check if resolve file is read in in case it is used by CMake in argument"
-  (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
-         (idb (cide--cdb-json-string-to-idb
-               (concat "[{\"file\": \"file1\",
+  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+    (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
+           (idb (cide--cdb-json-string-to-idb
+                 (concat "[{\"file\": \"file1\",
                   \"arguments\": [\"cmd1\", " "\"@" temporary-filename "\", " "\"-Ifoo\", \"-Ibar\", \"-std=c++14\", \"--foo\", \"--bar\"]},
                  {\"file\": \"file2\",
                   \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]")))
-         (file-params (cide--idb-file-to-obj idb "file1")))
-    (with-temp-file temporary-filename
-      (insert "-fmessage-length=0 -nostdlib"))
-    (let ((args (cide--file-params-to-args file-params)))
-      (should (equal args '("cmd1" "-fmessage-length=0" "-nostdlib" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
-    (delete-file temporary-filename))
+           (file-params (cide--idb-file-to-obj idb "file1")))
+      (with-temp-file temporary-filename
+        (insert "-fmessage-length=0 -nostdlib"))
+      (let ((args (cide--file-params-to-args file-params)))
+        (should (equal args '("cmd1" "-fmessage-length=0" "-nostdlib" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
+      (delete-file temporary-filename)))
   )
 
 

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -466,8 +466,8 @@ company-c-headers to break."
   )
 
 
-(ert-deftest test-get-command-args-with-resolve-file ()
-  "Check if resolve file is read in in case it is used by CMake"
+(ert-deftest test-get-command-args-with-resolve-file-in-command ()
+  "Check if resolve file is read in in case it is used by CMake in command"
   (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
          (idb (cide--cdb-json-string-to-idb
                (concat "[{\"file\": \"file1\",
@@ -476,11 +476,11 @@ company-c-headers to break."
                   \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]")))
          (file-params (cide--idb-file-to-obj idb "file1")))
     (with-temp-file temporary-filename
-      (insert "-fmessage-length=0")
+      (insert "-fmessage-length=0 -nostdlib")
       (end-of-line)
       (newline))
     (let ((args (cide--file-params-to-args file-params)))
-      (should (equal args '("cmd1" "-fmessage-length=0" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
+      (should (equal args '("cmd1" "-fmessage-length=0" "-nostdlib" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
     (delete-file temporary-filename))
   )
 
@@ -495,6 +495,23 @@ company-c-headers to break."
          (file-params (cide--idb-file-to-obj idb "file1"))
          (args (cide--file-params-to-args file-params)))
     (should (equal args '("cmd1" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
+  )
+
+
+(ert-deftest test-get-command-args-with-resolve-file-in-arguments ()
+  "Check if resolve file is read in in case it is used by CMake in argument"
+  (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
+         (idb (cide--cdb-json-string-to-idb
+               (concat "[{\"file\": \"file1\",
+                  \"arguments\": [\"cmd1\", " "\"@" temporary-filename "\", " "\"-Ifoo\", \"-Ibar\", \"-std=c++14\", \"--foo\", \"--bar\"]},
+                 {\"file\": \"file2\",
+                  \"command\": \"cmd2 foo bar -g -pg -Ibaz -Iboo -Dloo\"}]")))
+         (file-params (cide--idb-file-to-obj idb "file1")))
+    (with-temp-file temporary-filename
+      (insert "-fmessage-length=0 -nostdlib"))
+    (let ((args (cide--file-params-to-args file-params)))
+      (should (equal args '("cmd1" "-fmessage-length=0" "-nostdlib" "-Ifoo" "-Ibar" "-std=c++14" "--foo" "--bar"))))
+    (delete-file temporary-filename))
   )
 
 

--- a/test/utils-test.el
+++ b/test/utils-test.el
@@ -79,16 +79,19 @@
   (should-error (test-get-buffer-file-name nil)))
 
 (ert-deftest test-get-system-filename ()
-  (should
-   (progn
-     (make-local-variable system-type)
-     (setq system-type 'windows-nt)
-     (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "c:/mytestpath/myfile.cpp")))
-  (should
-   (progn
-     (make-local-variable system-type)
-     (setq system-type 'any-other-system)
-     (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "C:/MyTestPath/MyFile.cpp"))))
+  (let ((initial-system-type system-type))
+    (should
+     (progn
+       (make-local-variable system-type)
+       (setq system-type 'windows-nt)
+       (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "c:/mytestpath/myfile.cpp")
+       (setq system-type initial-system-type)))
+    (should
+     (progn
+       (make-local-variable system-type)
+       (setq system-type 'any-other-system)
+       (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "C:/MyTestPath/MyFile.cpp")
+       (setq system-type initial-system-type)))))
 
 (ert-deftest test-get-file-params ()
   (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))

--- a/test/utils-test.el
+++ b/test/utils-test.el
@@ -90,13 +90,6 @@
      (setq system-type 'any-other-system)
      (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "C:/MyTestPath/MyFile.cpp"))))
 
-(ert-deftest test-replace-param-in-region ()
-  (let* ((text "-DTEST pattern -ftest")
-         (match-begin (string-match "pattern" text))
-         (match-end (match-end 0))
-         (new-text "-fmessage-length=0"))
-    (should (equal (cide--replace-params-in-region text new-text match-begin match-end) "-DTEST -fmessage-length=0 -ftest"))))
-
 (ert-deftest test-get-file-params ()
   (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
     (let ((temporary-filename (make-temp-file "test-get-file-params")))

--- a/test/utils-test.el
+++ b/test/utils-test.el
@@ -99,8 +99,11 @@
       (with-temp-file temporary-filename
         (insert "-fmessage-length=0")
         (end-of-line)
+        (newline)
+        (insert "-nostdlib")
+        (end-of-line)
         (newline))
-      (should (equal (cide--get-file-params temporary-filename) "-fmessage-length=0"))
+      (should (equal (cide--get-file-params temporary-filename) "-fmessage-length=0 -nostdlib "))
       (delete-file temporary-filename)))
   (should-error (cide--get-file-params nil)))
 

--- a/test/utils-test.el
+++ b/test/utils-test.el
@@ -101,5 +101,27 @@
       (delete-file temporary-filename)))
   (should-error (cide--get-file-params nil)))
 
+(ert-deftest test-replace-response-file ()
+  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+    (let ((temporary-filename (make-temp-file "test-get-file-params")))
+      (with-temp-file temporary-filename
+        (insert "-fmessage-length=0 -nostdlib")
+        (end-of-line)
+        (newline))
+      (should (equal (cide--replace-response-file (concat "@" temporary-filename)) (list "-fmessage-length=0" "-nostdlib")))
+      (delete-file temporary-filename)))
+  )
+
+(ert-deftest test-resolve-response-file ()
+  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+    (let ((temporary-filename (make-temp-file "test-get-file-params")))
+      (with-temp-file temporary-filename
+        (insert "-fmessage-length=0 -nostdlib")
+        (end-of-line)
+        (newline))
+      (should (equal (cide--resolve-response-file (list "-Iinclude" (concat "@" temporary-filename))) (list "-Iinclude" "-fmessage-length=0" "-nostdlib")))
+      (delete-file temporary-filename)))
+  )
+
 (provide 'utils-test)
 ;;; utils-test.el ends here

--- a/test/utils-test.el
+++ b/test/utils-test.el
@@ -33,6 +33,7 @@
 (add-to-list 'load-path cide--root-path)
 
 (require 'ert)
+(require 'cl)
 (require 'cmake-ide)
 
 
@@ -69,6 +70,43 @@
 (ert-deftest test-filter-first ()
   (should (equal (cide--filter-first (lambda (x) (equal x "foo")) '("bar" "foo")) "foo"))
   (should (equal (cide--filter-first (lambda (x) (equal x "quux")) '("bar" "foo")) nil)))
+
+(ert-deftest test-get-buffer-file-name ()
+  (cl-letf (((symbol-function 'cide--get-system-filename) #'(lambda (filename) filename)))
+    (let* ((utils-test-buffer (find-file "utils-test.el"))
+           (utils-test-filename (buffer-file-name (get-buffer "utils-test.el"))))
+      (should (equal (cide--get-buffer-file-name utils-test-buffer) utils-test-filename))))
+  (should-error (test-get-buffer-file-name nil)))
+
+(ert-deftest test-get-system-filename ()
+  (should
+   (progn
+     (make-local-variable system-type)
+     (setq system-type 'windows-nt)
+     (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "c:/mytestpath/myfile.cpp")))
+  (should
+   (progn
+     (make-local-variable system-type)
+     (setq system-type 'any-other-system)
+     (equal (cide--get-system-filename "C:/MyTestPath/MyFile.cpp") "C:/MyTestPath/MyFile.cpp"))))
+
+(ert-deftest test-replace-param-in-region ()
+  (let* ((text "-DTEST pattern -ftest")
+         (match-begin (string-match "pattern" text))
+         (match-end (match-end 0))
+         (new-text "-fmessage-length=0"))
+    (should (equal (cide--replace-params-in-region text new-text match-begin match-end) "-DTEST -fmessage-length=0 -ftest"))))
+
+(ert-deftest test-get-file-params ()
+  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+    (let ((temporary-filename (make-temp-file "test-get-file-params")))
+      (with-temp-file temporary-filename
+        (insert "-fmessage-length=0")
+        (end-of-line)
+        (newline))
+      (should (equal (cide--get-file-params temporary-filename) "-fmessage-length=0"))
+      (delete-file temporary-filename)))
+  (should-error (cide--get-file-params nil)))
 
 (provide 'utils-test)
 ;;; utils-test.el ends here


### PR DESCRIPTION
Three changes required: 
(1) cmake-ide reads file paths with a lowcase c: for drive whereas CMake creates a capital C: for file path
-Since for pratical reasons Windows is case insensitive, downcasing on puthash and gethash if Windows

(2) CMake create response files with compiler call arguments in Windows to avoid reaching maximum number of characters in compiler call - response files are input starting with a @ 
-In the process of settings flags for a file (cmake-ide--set-flags-for-file) - read the contents of response files and translate into compiler arguments

(3) Clang binary on Windows uses the Microsoft compiler headers - user can set a cross compilation based on GNU by inputting --target i686-pc-windows-gnu (requires MinGW headers then)
-For that, consider cmake-ide-flags-c/c++ when evaluating args for flycheck-clang-args. 

Notice: I wonder if it wouldn't be beneficial to do the same with include-path and definitions