### PR TITLE
Strict match for the "-o" gcc option when filtering args for c/c++-gcc checker

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -1169,7 +1169,7 @@ returned unchanged."
   "Filter out '-o <output>' from the provided 'args' list."
   (if (not args)
       nil
-    (if (cide--string-match "^-o" (car args))
+    (if (string-equal "-o" (car args))
 	(nthcdr 2 args) ;; We assume '-o <output>' is provided only once, hence we stop recursion here. 
       (cons (car args) (cide--filter-output-arg (cdr args))))))
 

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -547,7 +547,7 @@ company-c-headers to break."
 
 
 (ert-deftest test-cide--filter-output-arg ()
-  (should (equal (cide--filter-output-arg '("-fPIC" "-o" "output" "-Wall")) '("-fPIC" "-Wall") )))
+  (should (equal (cide--filter-output-arg '("-fPIC" "-O3" "-march=native" "-o" "output" "-Wall")) '("-fPIC" "-O3" "-march=native" "-Wall") )))
 
 (ert-deftest test-split-command ()
   (should (equal (cide--split-command "foo \"quux toto\" bar") '("foo" "quux toto" "bar"))))


### PR DESCRIPTION
The identification of the option with the regexp "^-o" was too sloppy, as it was also matching optimisation flags (e.g. "-O3").
Now the match is exact, and the test has been modified in order to include an optimisation flag.