### PR TITLE
Get response file from (cide--build-dir) not (cide--build-dir-from-cache)

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -776,7 +776,7 @@ Return nil for non-CMake project."
 
 (defun cide--get-file-params (response-file)
   "Get file parameters from a response file given as compilation argument."
-  (replace-regexp-in-string "\\\n" " " (cide--get-string-from-file (expand-file-name response-file (cide--build-dir-from-cache)))))
+  (replace-regexp-in-string "\\\n" " " (cide--get-string-from-file (expand-file-name response-file (cide--build-dir)))))
 
 (defun cide--quote-if-spaces (str)
   "Add quotes to STR if it has spaces."

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -480,7 +480,7 @@ company-c-headers to break."
 
 (ert-deftest test-get-command-args-with-resolve-file-in-command ()
   "Check if resolve file is read in in case it is used by CMake in command"
-  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+  (cl-letf (((symbol-function 'cide--build-dir) #'(lambda () nil)))
     (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
            (idb (cide--cdb-json-string-to-idb
                  (concat "[{\"file\": \"file1\",
@@ -516,7 +516,7 @@ company-c-headers to break."
 
 (ert-deftest test-get-command-args-with-resolve-file-in-arguments ()
   "Check if resolve file is read in in case it is used by CMake in argument"
-  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+  (cl-letf (((symbol-function 'cide--build-dir) #'(lambda () nil)))
     (let* ((temporary-filename (make-temp-file "test-get-command-args-with-resolve-file"))
            (idb (cide--cdb-json-string-to-idb
                  (concat "[{\"file\": \"file1\",

--- a/test/utils-test.el
+++ b/test/utils-test.el
@@ -94,8 +94,10 @@
        (setq system-type initial-system-type)))))
 
 (ert-deftest test-get-file-params ()
-  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
-    (let ((temporary-filename (make-temp-file "test-get-file-params")))
+  (let ((temporary-filename (make-temp-file "test-get-file-params"))
+        (cide--build-dir-called nil)
+        (return-value nil))
+    (cl-letf (((symbol-function 'cide--build-dir) #'(lambda () (setq cide--build-dir-called t return-value nil))))
       (with-temp-file temporary-filename
         (insert "-fmessage-length=0")
         (end-of-line)
@@ -104,11 +106,12 @@
         (end-of-line)
         (newline))
       (should (equal (cide--get-file-params temporary-filename) "-fmessage-length=0 -nostdlib "))
-      (delete-file temporary-filename)))
+      (should (equal cide--build-dir-called t)))
+    (delete-file temporary-filename))
   (should-error (cide--get-file-params nil)))
 
 (ert-deftest test-replace-response-file ()
-  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+  (cl-letf (((symbol-function 'cide--build-dir) #'(lambda () nil)))
     (let ((temporary-filename (make-temp-file "test-get-file-params")))
       (with-temp-file temporary-filename
         (insert "-fmessage-length=0 -nostdlib")
@@ -119,7 +122,7 @@
   )
 
 (ert-deftest test-resolve-response-file ()
-  (cl-letf (((symbol-function 'cide--build-dir-from-cache) #'(lambda () nil)))
+  (cl-letf (((symbol-function 'cide--build-dir) #'(lambda () nil)))
     (let ((temporary-filename (make-temp-file "test-get-file-params")))
       (with-temp-file temporary-filename
         (insert "-fmessage-length=0 -nostdlib")


### PR DESCRIPTION
This error was uncovered late on validation phase because my test development and validation machines differ - sorry for that. Enhancing unit test to check call of (cide--build-dir) on (cide--get-file-params). 