### PR TITLE
avoid errors due to exceeding `max-lisp-eval-depth' when recursing

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -1196,13 +1196,16 @@ returned unchanged."
      ((cide--valid-cppcheck-standard-p gnu-replaced) gnu-replaced)
      ;; Otherwise, just hand back the original input.
      (t standard))))
+
 (defun cide--filter-output-arg (args)
   "Filter out '-o <output>' from the provided 'args' list."
-  (if (not args)
-      nil
-    (if (string-equal "-o" (car args))
-	(nthcdr 2 args) ;; We assume '-o <output>' is provided only once, hence we stop recursion here.
-      (cons (car args) (cide--filter-output-arg (cdr args))))))
+  (let (result)
+      (while args
+        (if (string-equal "-o" (car args))
+            (setq args (nthcdr 2 args))
+          (push (car args) result)
+          (setq args (cdr args))))
+      (nreverse result)))
 
 (provide 'cmake-ide)
 ;;; cmake-ide.el ends here

--- a/test/cmake-ide-test.el
+++ b/test/cmake-ide-test.el
@@ -617,7 +617,12 @@ company-c-headers to break."
 
 
 (ert-deftest test-cide--filter-output-arg ()
-  (should (equal (cide--filter-output-arg '("-fPIC" "-O3" "-march=native" "-o" "output" "-Wall")) '("-fPIC" "-O3" "-march=native" "-Wall") )))
+  (should (equal (cide--filter-output-arg '()) '()))
+  (should (equal (cide--filter-output-arg '("-fPIC" "-O3" "-march=native" "-Wall")) '("-fPIC" "-O3" "-march=native" "-Wall")))
+  (should (equal (cide--filter-output-arg '("-o" "output" "-fPIC" "-O3" "-march=native" "-Wall")) '("-fPIC" "-O3" "-march=native" "-Wall")))
+  (should (equal (cide--filter-output-arg '("-o" "output1" "-o" "output2" "-fPIC" "-O3" "-march=native" "-Wall")) '("-fPIC" "-O3" "-march=native" "-Wall")))
+  (should (equal (cide--filter-output-arg '("-fPIC" "-O3" "-march=native" "-Wall" "-o" "output")) '("-fPIC" "-O3" "-march=native" "-Wall")))
+  (should (equal (cide--filter-output-arg '("-fPIC" "-O3" "-march=native" "-o" "output" "-Wall")) '("-fPIC" "-O3" "-march=native" "-Wall"))))
 
 (ert-deftest test-split-command ()
   (should (equal (cide--split-command "foo \"quux toto\" bar") '("foo" "quux toto" "bar"))))


### PR DESCRIPTION
Hi Atila,

I use _cmake-ide_ in a large project with `cmake-ide-header-search-first-including` set to `nil`.  I'm getting errors regarding `max-lisp-eval-depth` being exceeded.
The following change fixed the issue for me.   Would you please consider integrating it?  Thank you very much, also for _cmake-ide_!

Greetings,

 Emílio