### PR TITLE
Fix cmake invocation if build exists in project-dir

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -691,7 +691,8 @@ the object file's name just above."
       (cide--message "Running cmake for src path %s in build path %s" project-dir cmake-dir)
       (apply 'start-process (append (list "cmake" "*cmake*" cmake-ide-cmake-command)
                                     (cide--cmake-args)
-                                    (list "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" project-dir))))))
+                                    (list "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+                                          "-S" project-dir "-B" "."))))))
 
 
 (defun cide--project-key ()


### PR DESCRIPTION
According to 'man cmake', the first non-option argument is ambiguous:
`"{<path-to-source> | <path-to-existing-build>}"`

If a build is already present in project-dir (yes, bad practice), then
cmake will use that as build directory (instead of cwd). As a result,
compile_commands.json ends up in project-dir, not where we look for it.