### PR TITLE
for older cmake versions

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -692,7 +692,7 @@ the object file's name just above."
       (apply 'start-process (append (list "cmake" "*cmake*" cmake-ide-cmake-command)
                                     (cide--cmake-args)
                                     (list "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-                                          "-S" project-dir "-B" "."))))))
+                                          "-B" "." "-S" project-dir))))))
 
 
 (defun cide--project-key ()


### PR DESCRIPTION
related to [#185](https://github.com/atilaneves/cmake-ide/pull/185)

I am using `cmake version 3.10.2` ubuntu 18.04

cmake cann't recognize -B -S options, so it takes the last argument as the source.

error generated : `CMake Error: The source directory "/tmp/cmake30805wdZ" does not appear to contain CMakeLists.txt`

swapping the order solved this issue for me.