### PR TITLE
Add configuration of compile_commands.json for flycheck-clang-tidy

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -664,6 +664,8 @@ the object file's name just above."
           (setq flycheck-clang-args args)
           (setq flycheck-gcc-args (cide--filter-output-arg args))
 
+          (setq flycheck-clang-tidy-build-path (cide--comp-db-file-name))
+
           (make-local-variable 'flycheck-clang-language-standard)
           (make-local-variable 'flycheck-gcc-language-standard)
           (let* ((stds (cide--filter (lambda (x) (string-match std-regex x)) flags))


### PR DESCRIPTION
I briefly looked at the test framework to add some test to verify the functionality. However, I couldn't find anything related to the compile commands in the test folder so I dropped the idea for now. Verified with a small setup using a cmake-file and with a compile_commands.json file (and no cmake-file).