### PR TITLE
fix: bug introduced when `flags` assumed to be a string

### DIFF
--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -978,7 +978,13 @@ Return nil for non-CMake project."
 (defun cide--get-compiler-flags (flags)
   "Use FLAGS to return all compiler flags including existing ones.
 Returns a list of strings."
-  (append (split-string (cide--get-existing-compiler-flags)) flags))
+  (condition-case nil
+      ;; Assume flags is a string
+      (append (split-string (cide--get-existing-compiler-flags)) flags)
+    ;; On exception
+    (wrong-type-argument
+     ;; Treat as list of strings.
+     (append (cide--get-existing-compiler-flags) flags))))
 
 (defun cide--get-existing-compiler-flags ()
   "Return existing ac-clang flags for this mode, if set.
@@ -1247,6 +1253,7 @@ The IDB is hash mapping files to all JSON objects (usually only one) in the CDB.
             (set-process-query-on-exit-flag rdm-process nil)))))))
 
   
+
 (defun cide--process-running-p (name)
   "If a process called NAME is running or not."
   (or (get-process name) (cide--system-process-running-p name)))

--- a/cmake-ide.el
+++ b/cmake-ide.el
@@ -1252,7 +1252,6 @@ The IDB is hash mapping files to all JSON objects (usually only one) in the CDB.
             (sleep-for 0.8)
             (set-process-query-on-exit-flag rdm-process nil)))))))
 
-  
 
 (defun cide--process-running-p (name)
   "If a process called NAME is running or not."


### PR DESCRIPTION
The latest merge (#209) assumed `flags` was always a string that needed splitting. This doesn't seem to be the case as it is a list of strings in my projects. The following fix allows for both cases. This should probably be investigated further as there should be no ambiguity in the type of `flags`.

I've tried (and failed) to run the unit tests for this project in order to add a test case. If you point me in the direction of how to get them working I can write one up.